### PR TITLE
Updating the redirectToProvider() method to use a relative redirect

### DIFF
--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ConnectController.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ConnectController.java
@@ -260,7 +260,7 @@ public class ConnectController  {
 	}
 
 	private RedirectView redirectToProvider(String providerId) {
-		return new RedirectView("/connect/" + providerId, true);
+		return new RedirectView(providerId, true);
 	}
 
 	private static final String OAUTH_TOKEN_ATTRIBUTE = "oauthToken";


### PR DESCRIPTION
Updating the redirectToProvider() method to use a relative redirect rather than absolute - if ConnectController isn't at the root (e.g. in /foo) it seems to sometimes still redirect to /connect rather than /foo/connect (debugging showed that request.getContextPath() was coming up empty sometimes, and as a result a relative redirect was not done). Doing the redirect relative to this servlet works correctly in those cases (since the servlet defines its path as /context).
