### PR TITLE
Updated build script to display a useful error message if Gradle NoClassDef seen

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -143,3 +143,9 @@ GRADLE_APP_BASE_NAME=`basename "$0"`
         -Dorg.gradle.wrapper.properties="$WRAPPER_PROPERTIES" \
         $STARTER_MAIN_CLASS \
         "$@"
+
+RETCODE=$?
+
+if [ "$RETCODE" == "1" ] ; then
+       echo "Gradle classes not found -- did you forget to clone --recursive when checking out this repository? See README for more details"
+fi


### PR DESCRIPTION
Updated the build script to display a useful error message in response to an error I encountered when I first pulled the project (I hadn't done clone --recursive, and got a Gradle-related noclassdef as a result)
