### PR TITLE
Changed JdbcConnectionRepository.addConnection to use COALESCE function instead of IFNULL

### DIFF
--- a/spring-social-core/src/main/java/org/springframework/social/connect/jdbc/JdbcConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/jdbc/JdbcConnectionRepository.java
@@ -163,7 +163,7 @@ class JdbcConnectionRepository implements ConnectionRepository {
 	public void addConnection(Connection<?> connection) {
 		try {
 			ConnectionData data = connection.createData();
-			int rank = jdbcTemplate.queryForInt("(select ifnull(max(rank) + 1, 1) as rank from " + tablePrefix + "UserConnection where userId = ? and providerId = ?)", userId, data.getProviderId());
+			int rank = jdbcTemplate.queryForInt("(select coalesce(max(rank) + 1, 1) as rank from " + tablePrefix + "UserConnection where userId = ? and providerId = ?)", userId, data.getProviderId());
 			jdbcTemplate.update("insert into " + tablePrefix + "UserConnection (userId, providerId, providerUserId, rank, displayName, profileUrl, imageUrl, accessToken, secret, refreshToken, expireTime) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
 					userId, data.getProviderId(), data.getProviderUserId(), rank, data.getDisplayName(), data.getProfileUrl(), data.getImageUrl(), encrypt(data.getAccessToken()), encrypt(data.getSecret()), encrypt(data.getRefreshToken()), data.getExpireTime());
 		} catch (DuplicateKeyException e) {


### PR DESCRIPTION
Just a small SQL change so that JdbcConnectionRepository.addConnection supports Postrgres 8.4 out of the box.  COALESCE is more widely supported than IFNULL and accomplishes the same thing.  See
http://www.nomadjourney.com/2009/04/database-independent-django-queries-coalesce/.  Forum discussion here: http://forum.springsource.org/showthread.php?111524-Issue-with-IFNULL-in-JdbcConnectionRepository-and-Postgres-8.4
