### PR TITLE
Allow ConnectionSignUp to indicate local account could not be created

### DIFF
--- a/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionSignUp.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionSignUp.java
@@ -26,7 +26,7 @@ public interface ConnectionSignUp {
 	/**
 	 * Sign up a new user of the application from the connection.
 	 * @param connection the connection
-	 * @return the new user id (must not be null).
+	 * @return the new user id (null indicates that an implicit local user profile could not be created).
 	 */
 	String execute(Connection<?> connection);
 

--- a/spring-social-core/src/main/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepository.java
@@ -84,8 +84,11 @@ public class JdbcUsersConnectionRepository implements UsersConnectionRepository 
 		List<String> localUserIds = jdbcTemplate.queryForList("select userId from " + tablePrefix + "UserConnection where providerId = ? and providerUserId = ?", String.class, key.getProviderId(), key.getProviderUserId());		
 		if (localUserIds.size() == 0 && connectionSignUp != null) {
 			String newUserId = connectionSignUp.execute(connection);
-			createConnectionRepository(newUserId).addConnection(connection);
-			return Arrays.asList(newUserId);
+			if (newUserId != null)
+			{
+				createConnectionRepository(newUserId).addConnection(connection);
+				return Arrays.asList(newUserId);
+			}
 		}
 		return localUserIds;
 	}

--- a/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepositoryTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepositoryTest.java
@@ -145,6 +145,18 @@ public class JdbcUsersConnectionRepositoryTest {
 		assertEquals(1, userIds.size());
 		assertEquals("batman", userIds.get(0));
 	}
+	
+	@Test
+	public void findUserIdWithConnectionNoConnection_withConnectionSignUpReturningNull() {		
+		Connection<TestFacebookApi> connection = connectionFactory.createConnection(new AccessGrant("12345"));
+		usersConnectionRepository.setConnectionSignUp(new ConnectionSignUp() {
+			public String execute(Connection<?> connection) {
+				return null;
+			}
+		});
+		List<String> userIds = usersConnectionRepository.findUserIdsWithConnection(connection);
+		assertEquals(0, userIds.size());
+	}
 
 	@Test
 	public void findUserIdsConnectedTo() {


### PR DESCRIPTION
When using ConnectionSignUp to implicitly create a local account for a user, it sometimes may not be possible to create the local account.   For instance, perhaps not enough information is available from the provider (eg. email address), or perhaps the user id used for the implicit sign up has already been taken.

To address these use cases, allow ConnectionSignUp to indicate that the creation of a local user account was attempted but was not completed, by enabling null user ids to be returned from the execute method.  
