### PR TITLE
Make ConnectController and ProviderSignInController more extendable

### DIFF
--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ConnectController.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ConnectController.java
@@ -68,13 +68,13 @@ public class ConnectController {
 	
 	private final static Log logger = LogFactory.getLog(ConnectController.class);
 	
-	private final ConnectionFactoryLocator connectionFactoryLocator;
+	protected final ConnectionFactoryLocator connectionFactoryLocator;
 	
 	private final ConnectionRepository connectionRepository;
 
 	private final MultiValueMap<Class<?>, ConnectInterceptor<?>> interceptors = new LinkedMultiValueMap<Class<?>, ConnectInterceptor<?>>();
 
-	private final ConnectSupport webSupport = new ConnectSupport();
+	protected final ConnectSupport webSupport = new ConnectSupport();
 	
 	private final UrlPathHelper urlPathHelper = new UrlPathHelper();
 
@@ -284,7 +284,7 @@ public class ConnectController {
 		return "connect/";
 	}
 	
-	private void addConnection(Connection<?> connection, ConnectionFactory<?> connectionFactory, WebRequest request) {
+	protected void addConnection(Connection<?> connection, ConnectionFactory<?> connectionFactory, WebRequest request) {
 		try {
 			connectionRepository.addConnection(connection);
 			postConnect(connectionFactory, connection, request);
@@ -294,7 +294,7 @@ public class ConnectController {
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
-	private void preConnect(ConnectionFactory<?> connectionFactory, MultiValueMap<String, String> parameters, WebRequest request) {
+	protected void preConnect(ConnectionFactory<?> connectionFactory, MultiValueMap<String, String> parameters, WebRequest request) {
 		for (ConnectInterceptor interceptor : interceptingConnectionsTo(connectionFactory)) {
 			interceptor.preConnect(connectionFactory, parameters, request);
 		}

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInController.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInController.java
@@ -51,7 +51,7 @@ public class ProviderSignInController {
 
 	private final static Log logger = LogFactory.getLog(ProviderSignInController.class);
 	
-	private final ConnectionFactoryLocator connectionFactoryLocator;
+	protected final ConnectionFactoryLocator connectionFactoryLocator;
 
 	private final UsersConnectionRepository usersConnectionRepository;
 	
@@ -63,7 +63,7 @@ public class ProviderSignInController {
 
 	private String postSignInUrl = "/";
 
-	private final ConnectSupport webSupport = new ConnectSupport();
+	protected final ConnectSupport webSupport = new ConnectSupport();
 
 	/**
 	 * Creates a new provider sign-in controller.
@@ -182,7 +182,7 @@ public class ProviderSignInController {
 
 	// internal helpers
 
-	private RedirectView handleSignIn(Connection<?> connection, NativeWebRequest request) {
+	protected RedirectView handleSignIn(Connection<?> connection, NativeWebRequest request) {
 		List<String> userIds = usersConnectionRepository.findUserIdsWithConnection(connection);
 		if (userIds.size() == 0) {
 			ProviderSignInAttempt signInAttempt = new ProviderSignInAttempt(connection, connectionFactoryLocator, usersConnectionRepository);


### PR DESCRIPTION
It would be really useful to be able to extend ConnectController and ProviderSignInController to add custom callback methods.  For example, the callbacks from LastFm's api are neither OAuth1 or OAuth2 but are similar (using a different request parameter name).   Adding new callback methods means requiring much of the functionality of the existing callback methods, but the existing callback methods use private helper methods and attributes.   Making the visibility of these helper methods and attributes protected rather than private would make extending these controllers easier. 

See 

https://github.com/michaellavelle/spring-social-lastfm-non-oauth-web/blob/master/src/main/java/org/springframework/social/lastfm/nonoauth/connect/web/LastFmNonOAuthSignInController.java

for an example of this use case.

This controller extends a custom controller class

https://github.com/socialsignin/spring-social-web-non-oauth-extension/blob/master/src/main/java/org/springframework/social/connect/web/ExtensibleProviderSignInController.java

but could simply extend the existing ProviderSignInController if these visibility modifications were made.
