### PR TITLE
Removed Guava test dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,6 @@ project('spring-social-web') {
         compile project(':spring-social-core')
         testCompile "org.springframework:spring-test-mvc:$springTestMvcVersion"
         testCompile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
-        testCompile "com.google.guava:guava:10.0"
     }
 }
 

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInController.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInController.java
@@ -196,7 +196,7 @@ public class ProviderSignInController {
 			ProviderSignInAttempt signInAttempt = new ProviderSignInAttempt(connection, connectionFactoryLocator, usersConnectionRepository);
 			request.setAttribute(ProviderSignInAttempt.SESSION_ATTRIBUTE, signInAttempt, RequestAttributes.SCOPE_SESSION);
 			return redirect(signUpUrl);
-		} else if (userIds.size() == 1){
+		} else if (userIds.size() == 1) {
 			usersConnectionRepository.createConnectionRepository(userIds.get(0)).updateConnection(connection);
 			String originalUrl = signInAdapter.signIn(userIds.get(0), connection, request);
 			return originalUrl != null ? redirect(originalUrl) : redirect(postSignInUrl);


### PR DESCRIPTION
Previously, I had added Guava to the test classpath because I was getting NoClassDefFoundErrors while testing in STS. I had wrongly assumed that Guava had become a transitive dependency of one of the test libraries. As it turns out, it was a bug in the Infinitest plugin that has since been fixed. (See https://github.com/infinitest/infinitest/issues/73 for details on the bug.)
