### PR TITLE
Fix Integer overflow in AccessGrant

### DIFF
--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/AccessGrant.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/AccessGrant.java
@@ -40,7 +40,7 @@ public class AccessGrant implements Serializable {
 		this.accessToken = accessToken;
 		this.scope = scope;
 		this.refreshToken = refreshToken;
-		this.expireTime = expiresIn != null ? System.currentTimeMillis() + expiresIn * 1000 : null;
+		this.expireTime = expiresIn != null ? System.currentTimeMillis() + expiresIn * 1000l : null;
 	}
 
 	/**


### PR DESCRIPTION
The OAuth2 access grant produces the wrong expiry time when a large integer is passed in. This is because System.currentTimeMillis() (a Long) is added to expiryTime \* 1000 (an Integer).

This change, uses  expiryTime \* 1000l (a Long)
