### PR TITLE
Support for new Facebook endpoint to extend access token lifetime

### DIFF
--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Operations.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Operations.java
@@ -61,4 +61,12 @@ public interface OAuth2Operations {
 	 */
 	AccessGrant refreshAccess(String refreshToken, String scope, MultiValueMap<String, String> additionalParameters);
 	
+	/**
+	 * Request an extension of a short access grant to a longer one
+	 * @param refreshToken the refresh token from the previous access grant.
+	 * @param scope optional scope to narrow to when refreshing access; if null, the existing scope is preserved.
+	 * @param additionalParameters any additional parameters to be sent when refreshing a previous access grant. Should not be encoded. 
+	 * @return the access grant.
+	 */
+	AccessGrant extendAccess(String refreshToken, String scope, MultiValueMap<String, String> additionalParameters);
 }

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Template.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Template.java
@@ -40,11 +40,11 @@ import org.springframework.web.client.RestTemplate;
  */
 public class OAuth2Template implements OAuth2Operations {
 
-	private final String clientId;
+	protected final String clientId;
 	
-	private final String clientSecret;
+	protected final String clientSecret;
 
-	private final String accessTokenUrl;
+	protected final String accessTokenUrl;
 
 	private final String authorizeUrl;
 
@@ -119,6 +119,10 @@ public class OAuth2Template implements OAuth2Operations {
 		return postForAccessGrant(accessTokenUrl, params);
 	}
 
+	public AccessGrant extendAccess(String refreshToken, String scope, MultiValueMap<String, String> additionalParameters) {
+		return refreshAccess(refreshToken, scope, additionalParameters);
+	}
+	
 	// subclassing hooks
 	
 	/**

--- a/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepositoryTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepositoryTest.java
@@ -480,7 +480,10 @@ public class JdbcUsersConnectionRepositoryTest {
 				}
 				public AccessGrant refreshAccess(String refreshToken, String scope, MultiValueMap<String, String> additionalParameters) {
 					return new AccessGrant("765432109", "read", "654321098", 3600);
-				}								
+				}						
+				public AccessGrant extendAccess(String refreshToken, String scope, MultiValueMap<String, String> additionalParameters) {
+					return new AccessGrant("765432109", "read", "654321098", 3600);
+				}		
 			};
 		}
 

--- a/spring-social-core/src/test/java/org/springframework/social/connect/oauth2/StubOAuth2Operations.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/oauth2/StubOAuth2Operations.java
@@ -38,4 +38,8 @@ class StubOAuth2Operations implements OAuth2Operations {
 	public AccessGrant refreshAccess(String refreshToken, String scope, MultiValueMap<String, String> additionalParameters) {
 		return new AccessGrant("12345", null,  "23456", 3600);
 	}
+	
+	public AccessGrant extendAccess(String refreshToken, String scope, MultiValueMap<String, String> additionalParameters) {
+		return new AccessGrant("12345", null,  "23456", 3600);
+	}
 }

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/ConnectSupportTest.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/ConnectSupportTest.java
@@ -429,6 +429,9 @@ public class ConnectSupportTest {
 				public AccessGrant refreshAccess(String refreshToken, String scope, MultiValueMap<String, String> additionalParameters) {
 					return null;
 				}
+				public AccessGrant extendAccess(String refreshToken, String scope, MultiValueMap<String, String> additionalParameters) {
+					return null;
+				}
 			};
 		}
 


### PR DESCRIPTION
Facebook has begun supporting an OAuth2 extension to allow a server side request to exchange a short-lived Access Token for a Long-lived Access Token.  I've added support for this into the spring-social OAuth2Operations interface and the spring-social-facebook FacebookOAuth2Template, please consider this for addition into a future spring-social release.

Since this is Facebook-specific an alternate implementation would be to subclass the OAuth2Operations interface in the spring-social-facebook package and have the user upcast the object from connectionFactory.getOAuthOperations().  This would be better because it would not add a Facebook specific API to the base class interface, however, it may be possible that what Facebook has done will somehow become part of a future OAuth standard and so it will need to be added to the base API at some point anyway.

Certainly interested in any insights SpringSource has into Facebook's deprecation of offline_access mode.  Feel free to contact me at jphillips@tango.me for more info about my submitted changes.
