### PR TITLE
SOCIAL-324: No-arg authenticateClient()

### DIFF
--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Operations.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Operations.java
@@ -83,6 +83,13 @@ public interface OAuth2Operations {
 	/**
 	 * Retrieves the client access grant using OAuth 2 client password flow.
 	 * This is an access grant that is based on the client id and password (a.k.a. client secret).
+	 * @return the access grant of the client only (not user related)
+	 */
+	AccessGrant authenticateClient();
+
+	/**
+	 * Retrieves the client access grant using OAuth 2 client password flow.
+	 * This is an access grant that is based on the client id and password (a.k.a. client secret).
 	 * @param scope optional scope to get for the access grant
 	 * @return the access grant of the client only (not user related)
 	 */

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Template.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Template.java
@@ -170,6 +170,10 @@ public class OAuth2Template implements OAuth2Operations {
 		return postForAccessGrant(accessTokenUrl, params);
 	}
 
+	public AccessGrant authenticateClient() {
+		return authenticateClient(null);
+	}
+	
 	public AccessGrant authenticateClient(String scope) {
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<String, String>();
 		if (useParametersForClientAuthentication) {

--- a/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepositoryTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepositoryTest.java
@@ -487,7 +487,9 @@ public class JdbcUsersConnectionRepositoryTest {
 				public AccessGrant refreshAccess(String refreshToken, String scope, MultiValueMap<String, String> additionalParameters) {
 					return new AccessGrant("765432109", "read", "654321098", 3600);
 				}
-
+				public AccessGrant authenticateClient() {
+					return null;
+				}
 				public AccessGrant authenticateClient(String scope) {
 					return null;
 				}

--- a/spring-social-core/src/test/java/org/springframework/social/connect/oauth2/StubOAuth2Operations.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/oauth2/StubOAuth2Operations.java
@@ -46,7 +46,9 @@ class StubOAuth2Operations implements OAuth2Operations {
 	public AccessGrant refreshAccess(String refreshToken, String scope, MultiValueMap<String, String> additionalParameters) {
 		return new AccessGrant("12345", null,  "23456", 3600);
 	}
-
+	public AccessGrant authenticateClient() {
+		return new AccessGrant("12345", null,  null, 3600);
+	}
 	public AccessGrant authenticateClient(String scope) {
 		return new AccessGrant("12345", null,  null, 3600);
 	}

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/ConnectSupportTest.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/ConnectSupportTest.java
@@ -426,6 +426,9 @@ public class ConnectSupportTest {
 				public AccessGrant refreshAccess(String refreshToken, MultiValueMap<String, String> additionalParameters) {
 					return null;
 				}
+				public AccessGrant authenticateClient() {
+					return null;
+				}
 				public AccessGrant authenticateClient(String scope) {
 					return null;
 				}


### PR DESCRIPTION
Added a convenient no-arg authenticateClient() so that null doesn't have to be passed in for the scope (which is the most typical case).
