### PR TITLE
Changle ConnectController to allow updating existing connections

### DIFF
--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ConnectController.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ConnectController.java
@@ -32,6 +32,7 @@ import org.springframework.social.connect.ConnectionFactoryLocator;
 import org.springframework.social.connect.ConnectionKey;
 import org.springframework.social.connect.ConnectionRepository;
 import org.springframework.social.connect.DuplicateConnectionException;
+import org.springframework.social.connect.NoSuchConnectionException;
 import org.springframework.social.connect.support.OAuth1ConnectionFactory;
 import org.springframework.social.connect.support.OAuth2ConnectionFactory;
 import org.springframework.stereotype.Controller;
@@ -216,7 +217,7 @@ public class ConnectController {
 		try {
 			OAuth1ConnectionFactory<?> connectionFactory = (OAuth1ConnectionFactory<?>) connectionFactoryLocator.getConnectionFactory(providerId);
 			Connection<?> connection = webSupport.completeConnection(connectionFactory, request);
-			addConnection(connection, connectionFactory, request);
+			addOrUpdateConnection(connection, connectionFactory, request);
 		} catch (Exception e) {
 			request.setAttribute(PROVIDER_ERROR_ATTRIBUTE, e, RequestAttributes.SCOPE_SESSION);
 			logger.warn("Exception while handling OAuth1 callback (" + e.getMessage() + "). Redirecting to " + providerId +" connection status page.");
@@ -234,7 +235,7 @@ public class ConnectController {
 		try {
 			OAuth2ConnectionFactory<?> connectionFactory = (OAuth2ConnectionFactory<?>) connectionFactoryLocator.getConnectionFactory(providerId);
 			Connection<?> connection = webSupport.completeConnection(connectionFactory, request);
-			addConnection(connection, connectionFactory, request);
+			addOrUpdateConnection(connection, connectionFactory, request);
 		} catch (Exception e) {
 			request.setAttribute(PROVIDER_ERROR_ATTRIBUTE, e, RequestAttributes.SCOPE_SESSION);
 			logger.warn("Exception while handling OAuth2 callback (" + e.getMessage() + "). Redirecting to " + providerId +" connection status page.");
@@ -336,13 +337,19 @@ public class ConnectController {
 		return "connect/";
 	}
 	
-	private void addConnection(Connection<?> connection, ConnectionFactory<?> connectionFactory, WebRequest request) {
-		try {
-			connectionRepository.addConnection(connection);
-			postConnect(connectionFactory, connection, request);
-		} catch (DuplicateConnectionException e) {
-			request.setAttribute(DUPLICATE_CONNECTION_ATTRIBUTE, e, RequestAttributes.SCOPE_SESSION);
-		}
+	private void addOrUpdateConnection(Connection<?> connection, ConnectionFactory<?> connectionFactory, WebRequest request) {
+	    	try {
+        		connectionRepository.getConnection(connection.getKey());
+        		connectionRepository.updateConnection(connection);
+        		postConnect(connectionFactory, connection, request);
+	    	} catch (NoSuchConnectionException ex) {
+			try {
+        			connectionRepository.addConnection(connection);
+        			postConnect(connectionFactory, connection, request);
+        		} catch (DuplicateConnectionException e) {
+        			request.setAttribute(DUPLICATE_CONNECTION_ATTRIBUTE, e, RequestAttributes.SCOPE_SESSION);
+        		}
+	    	}
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })


### PR DESCRIPTION
If I walk user through connection flow, but there's already connection for this user and provider, DuplicateConnectionException is thrown and an old connection isn't replaced with a new one. 
This becomes real problem when the old connection is actually expired and so it **must** be replaced with a new one. 
I must therefore invent some additional logic to first remove the old connection, and then add the new one. I must go to this trouble, while there exists perfectly capable updateConnection() method in ConnectionRepository. 

I propose changing ConnectController, so it will update existing connection on oauth success callback if such connection already exists and create a new one otherwise. 
