### PR TITLE
Add subclassing hook to ProviderConfigurationSupport to allow the constr...

### DIFF
--- a/spring-social-config/src/main/java/org/springframework/social/config/support/ProviderConfigurationSupport.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/support/ProviderConfigurationSupport.java
@@ -68,7 +68,7 @@ public abstract class ProviderConfigurationSupport {
 			registerConnectionFactoryBeanDefinitions(registry, allAttributes);			
 		}
 		
-		return registerApiBindingBean(registry, apiHelperClass, apiBindingType);
+		return registerApiBindingBean(registry, apiHelperClass, apiBindingType,allAttributes);
 	}
 	
 	protected abstract String getAppId(Map<String, Object> allAttributes);
@@ -129,13 +129,13 @@ public abstract class ProviderConfigurationSupport {
 		return authenticationServiceBD;
 	}
 	
-	private BeanDefinition registerApiBindingBean(BeanDefinitionRegistry registry, Class<? extends ApiHelper<?>> apiHelperClass, Class<?> apiBindingType) {
+	private BeanDefinition registerApiBindingBean(BeanDefinitionRegistry registry, Class<? extends ApiHelper<?>> apiHelperClass, Class<?> apiBindingType,Map<String, Object> allAttributes) {
 		if (logger.isDebugEnabled()) {
 			logger.debug("Registering API Helper bean for " + ClassUtils.getShortName(apiBindingType));
 		}		
 		String helperId = "__" + ClassUtils.getShortNameAsProperty(apiBindingType) + "ApiHelper";
 		// TODO: Make the bean IDs here configurable.
-		BeanDefinition helperBD = BeanDefinitionBuilder.genericBeanDefinition(apiHelperClass).addConstructorArgReference("usersConnectionRepository").addConstructorArgReference("userIdSource").getBeanDefinition();
+		BeanDefinition helperBD = getApiHelperBeanDefinitionBuilder(allAttributes).getBeanDefinition();
 		registry.registerBeanDefinition(helperId, helperBD);
 		
 		if (logger.isDebugEnabled()) {
@@ -148,6 +148,14 @@ public abstract class ProviderConfigurationSupport {
 		BeanDefinitionHolder scopedProxyBDH = ScopedProxyUtils.createScopedProxy(new BeanDefinitionHolder(bindingBD, ClassUtils.getShortNameAsProperty(apiBindingType)), registry, false);
 		registry.registerBeanDefinition(scopedProxyBDH.getBeanName(), scopedProxyBDH.getBeanDefinition());
 		return scopedProxyBDH.getBeanDefinition();
+	}
+	
+	/**
+	 * Subclassing hook to allow api helper bean to be configured with attributes from annotation
+	 */
+	protected BeanDefinitionBuilder getApiHelperBeanDefinitionBuilder(Map<String, Object> allAttributes)
+	{
+		return BeanDefinitionBuilder.genericBeanDefinition(apiHelperClass).addConstructorArgReference("usersConnectionRepository").addConstructorArgReference("userIdSource");
 	}
 
 	protected final Class<? extends ConnectionFactory<?>> connectionFactoryClass;


### PR DESCRIPTION
The getApi() method of ApiHelper returns a non user-specific API binding if a user-specific connection is not available (eg FacebookApiHelper returns default FacebookTemplate).

For some providers, the construction of this non user-specific binding will require constructor args - for example SoundCloudTemplate and LastFmTemplate both require apiKey for all operations,  TwitterTemplate will require appKey,appSecret and client authentication scope to obtain a client authenticated access token.

Add a subclassing hook to ProviderConfigurationSupport  ( getApiHelperBeanDefinitionBuilder() method ) to allow provider implementations to configure the ApiHelper bean with additional parameters. 