### PR TITLE
SOCIAL-406 Allow adding connections to authenticated users via SocialAuthenticationFilter

### DIFF
--- a/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionData.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionData.java
@@ -30,23 +30,23 @@ import org.springframework.social.connect.support.OAuth2Connection;
 @SuppressWarnings("serial")
 public class ConnectionData implements Serializable {
 	
-	private String providerId;
+	private final String providerId;
 	
-	private String providerUserId;
+	private final String providerUserId;
 	
-	private String displayName;
+	private final String displayName;
 	
-	private String profileUrl;
+	private final String profileUrl;
 	
-	private String imageUrl;
+	private final String imageUrl;
 	
-	private String accessToken;
+	private final String accessToken;
 	
-	private String secret;
+	private final String secret;
 	
-	private String refreshToken;
+	private final String refreshToken;
 	
-	private Long expireTime;
+	private final Long expireTime;
 
 	public ConnectionData(String providerId, String providerUserId, String displayName, String profileUrl, String imageUrl, String accessToken, String secret, String refreshToken, Long expireTime) {
 		this.providerId = providerId;
@@ -134,5 +134,96 @@ public class ConnectionData implements Serializable {
 	public Long getExpireTime() {
 		return expireTime;
 	}
-		
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result
+				+ ((accessToken == null) ? 0 : accessToken.hashCode());
+		result = prime * result
+				+ ((displayName == null) ? 0 : displayName.hashCode());
+		result = prime * result
+				+ ((expireTime == null) ? 0 : expireTime.hashCode());
+		result = prime * result
+				+ ((imageUrl == null) ? 0 : imageUrl.hashCode());
+		result = prime * result
+				+ ((profileUrl == null) ? 0 : profileUrl.hashCode());
+		result = prime * result
+				+ ((providerId == null) ? 0 : providerId.hashCode());
+		result = prime * result
+				+ ((providerUserId == null) ? 0 : providerUserId.hashCode());
+		result = prime * result
+				+ ((refreshToken == null) ? 0 : refreshToken.hashCode());
+		result = prime * result + ((secret == null) ? 0 : secret.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (!(obj instanceof ConnectionData))
+			return false;
+		ConnectionData other = (ConnectionData) obj;
+		if (accessToken == null) {
+			if (other.accessToken != null)
+				return false;
+		} else if (!accessToken.equals(other.accessToken))
+			return false;
+		if (displayName == null) {
+			if (other.displayName != null)
+				return false;
+		} else if (!displayName.equals(other.displayName))
+			return false;
+		if (expireTime == null) {
+			if (other.expireTime != null)
+				return false;
+		} else if (!expireTime.equals(other.expireTime))
+			return false;
+		if (imageUrl == null) {
+			if (other.imageUrl != null)
+				return false;
+		} else if (!imageUrl.equals(other.imageUrl))
+			return false;
+		if (profileUrl == null) {
+			if (other.profileUrl != null)
+				return false;
+		} else if (!profileUrl.equals(other.profileUrl))
+			return false;
+		if (providerId == null) {
+			if (other.providerId != null)
+				return false;
+		} else if (!providerId.equals(other.providerId))
+			return false;
+		if (providerUserId == null) {
+			if (other.providerUserId != null)
+				return false;
+		} else if (!providerUserId.equals(other.providerUserId))
+			return false;
+		if (refreshToken == null) {
+			if (other.refreshToken != null)
+				return false;
+		} else if (!refreshToken.equals(other.refreshToken))
+			return false;
+		if (secret == null) {
+			if (other.secret != null)
+				return false;
+		} else if (!secret.equals(other.secret))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "ConnectionData [providerId=" + providerId + ", providerUserId="
+				+ providerUserId + ", displayName=" + displayName
+				+ ", profileUrl=" + profileUrl + ", imageUrl=" + imageUrl
+				+ ", accessToken=" + accessToken + ", secret=" + secret
+				+ ", refreshToken=" + refreshToken + ", expireTime="
+				+ expireTime + "]";
+	}
+
 }

--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.social.security;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -23,7 +24,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -170,17 +170,24 @@ public class SocialAuthenticationFilter extends AbstractAuthenticationProcessing
 			throw new SocialAuthenticationException("Authentication failed because user rejected authorization.");
 		}
 		
-		Authentication auth = null;
 		Set<String> authProviders = authServiceLocator.registeredAuthenticationProviderIds();
 		String authProviderId = getRequestedProviderId(request);
+
 		if (!authProviders.isEmpty() && authProviderId != null && authProviders.contains(authProviderId)) {
-			SocialAuthenticationService<?> authService = authServiceLocator.getAuthenticationService(authProviderId);
-			auth = attemptAuthService(authService, request, response);
-			if (auth == null) {
-				throw new AuthenticationServiceException("authentication failed");
+			try {
+				SocialAuthenticationService<?> authService = authServiceLocator.getAuthenticationService(authProviderId);
+				return attemptAuthService(authService, request, response);
+			} catch (SocialAuthenticationRedirectException redirect) {
+				try {
+					response.sendRedirect(redirect.getRedirectUrl());
+				} catch (IOException e) {
+					throw new SocialAuthenticationException("failed to send redirect from SocialAuthenticationRedirectException", e);
+				}
+				return null;
 			}
+		} else {
+			return null;
 		}
-		return auth;
 	}
 
 	/**
@@ -223,9 +230,10 @@ public class SocialAuthenticationFilter extends AbstractAuthenticationProcessing
 		userIdSet.add(data.getProviderUserId());
 		Set<String> connectedUserIds = usersConnectionRepository.findUserIdsConnectedTo(data.getProviderId(), userIdSet);
 		if (connectedUserIds.contains(userId)) {
-			// already connected
+			// providerUserId already connected to userId
 			return null;
 		} else if (!authService.getConnectionCardinality().isMultiUserId() && !connectedUserIds.isEmpty()) {
+			// providerUserId already connected to different userId and no multi user allowed
 			return null;
 		}
 
@@ -311,10 +319,13 @@ public class SocialAuthenticationFilter extends AbstractAuthenticationProcessing
 	private void addConnection(final SocialAuthenticationService<?> authService, HttpServletRequest request, SocialAuthenticationToken token, Authentication auth) {
 		// already authenticated - add connection instead
 		String userId = userIdSource.getUserId();
-		Object principal = token.getPrincipal();
-		if (userId == null || !(principal instanceof ConnectionData)) return;
+		Connection<?> connection = token.getConnection();
+		if (userId == null || connection == null) {
+			logger.warn("can't add connection without userId or connection");
+			return;
+		}
 		
-		Connection<?> connection = addConnection(authService, userId, (ConnectionData) principal);
+		connection = addConnection(authService, userId, connection.createData());
 		if(connection != null) {
 			String redirectUrl = authService.getConnectionAddedRedirectUrl(request, connection);
 			if (redirectUrl == null) {

--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
@@ -62,6 +62,8 @@ public class SocialAuthenticationFilter extends AbstractAuthenticationProcessing
 
 	private String connectionAddedRedirectUrl = "/";
 
+	private String connectionAddingFailureRedirectUrl = "/";
+
 	private boolean updateConnections = true;
 
 	private UserIdSource userIdSource;
@@ -98,8 +100,21 @@ public class SocialAuthenticationFilter extends AbstractAuthenticationProcessing
 		setPostFailureUrl(defaultFailureUrl);
 	}
 
+	/**
+	 * an authenticated user can add additional connections. after successfully authorizing, the user
+	 * will be redirected to this URL
+	 */
 	public void setConnectionAddedRedirectUrl(String connectionAddedRedirectUrl) {
 		this.connectionAddedRedirectUrl = connectionAddedRedirectUrl;
+	}
+
+	/**
+	 * redirect the user after an attempt to add an additional authentication failed. After the failure
+	 * the user is still authenticated, so redirecting to something like {@value #DEFAULT_FAILURE_URL} might
+	 * not make sense
+	 */
+	public void setConnectionAddingFailureRedirectUrl(String connectionAddingFailureRedirectUrl) {
+		this.connectionAddingFailureRedirectUrl = connectionAddingFailureRedirectUrl;
 	}
 
 	public void setUpdateConnections(boolean updateConnections) {
@@ -266,15 +281,21 @@ public class SocialAuthenticationFilter extends AbstractAuthenticationProcessing
 		return SecurityContextHolder.getContext().getAuthentication();
 	}
 
-	/*
-	 * Call SocialAuthenticationService.getAuthToken() to get SocialAuthenticationToken:
-	 *     If first phase, throw AuthenticationRedirectException to redirect to provider website.
-	 *     If second phase, get token/code from request parameter and call provider API to get accessToken/accessGrant.
-	 * Check Authentication object in spring security context, if null or not authenticated,  call doAuthentication()
-	 * Otherwise, it is already authenticated, add this connection.
+	/**
+	 * @return the authenticated user token, or null if authentication is incomplete.
+	 * @throws AuthenticationException if authentication fails.
+	 * @see AbstractAuthenticationProcessingFilter#attemptAuthentication(HttpServletRequest, HttpServletResponse)
 	 */
-	private Authentication attemptAuthService(final SocialAuthenticationService<?> authService, final HttpServletRequest request, HttpServletResponse response) 
+	private Authentication attemptAuthService(final SocialAuthenticationService<?> authService, final HttpServletRequest request, HttpServletResponse response)
 			throws SocialAuthenticationRedirectException, AuthenticationException {
+
+		/*
+		 * Call SocialAuthenticationService.getAuthToken() to get SocialAuthenticationToken:
+		 *     If first phase, throw AuthenticationRedirectException to redirect to provider website.
+		 *     If second phase, get token/code from request parameter and call provider API to get accessToken/accessGrant.
+		 * Check Authentication object in spring security context, if null or not authenticated,  call doAuthentication()
+		 * Otherwise, it is already authenticated, add this connection.
+		 */
 
 		final SocialAuthenticationToken token = authService.getAuthToken(request, response);
 		if (token == null) return null;
@@ -287,7 +308,7 @@ public class SocialAuthenticationFilter extends AbstractAuthenticationProcessing
 		} else {
 			addConnection(authService, request, token, auth);
 			return null;
-		}		
+		}
 	}	
 	
 	private String getRequestedProviderId(HttpServletRequest request) {
@@ -333,6 +354,8 @@ public class SocialAuthenticationFilter extends AbstractAuthenticationProcessing
 				redirectUrl = connectionAddedRedirectUrl;
 			}
 			throw new SocialAuthenticationRedirectException(redirectUrl);
+		} else {
+			throw new SocialAuthenticationRedirectException(connectionAddingFailureRedirectUrl);
 		}
 	}
 

--- a/spring-social-security/src/test/java/org/springframework/social/security/SocialAuthenticationFilterTest.java
+++ b/spring-social-security/src/test/java/org/springframework/social/security/SocialAuthenticationFilterTest.java
@@ -163,6 +163,94 @@ public class SocialAuthenticationFilterTest {
 		verify(connectionRepository).addConnection(connection);
 	}
 	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void addConnection_authenticated() throws Exception {
+
+		FilterTestEnv env = new FilterTestEnv("GET", "/auth", null);
+		env.filter.setFilterProcessesUrl(env.req.getRequestURI());
+		env.filter.setPostLoginUrl("/success");
+		env.filter.setConnectionAddedRedirectUrl("/added");
+		env.filter.setConnectionAddingFailureRedirectUrl("/add-failed");
+
+		Connection<?> connection = env.auth.getConnection();
+		ConnectionData data = connection.createData();
+		String userId = "joe";
+
+		ConnectionFactory<Object> factory = mock(MockConnectionFactory.class);
+		when(factory.getProviderId()).thenReturn("mock");
+		when(factory.createConnection(data)).thenReturn((Connection<Object>) connection);
+		env.req.setRequestURI(env.req.getRequestURI() + "/" + factory.getProviderId());
+
+		SocialAuthenticationService<Object> authService = mock(SocialAuthenticationService.class);
+		when(authService.getConnectionCardinality()).thenReturn(ConnectionCardinality.ONE_TO_ONE);
+		when(authService.getConnectionFactory()).thenReturn(factory);
+		when(authService.getAuthToken(env.req, env.res)).thenReturn(env.auth);
+		env.addAuthService(authService);
+
+		when(env.userIdSource.getUserId()).thenReturn(userId);
+
+		when(env.usersConnectionRepository.findUserIdsConnectedTo(data.getProviderId(), set(data.getProviderUserId()))).thenReturn(empty(String.class));
+
+		// fallback to default /added
+		when(authService.getConnectionAddedRedirectUrl(env.req, connection)).thenReturn(null);
+
+		// already authenticated
+		SecurityContextHolder.getContext().setAuthentication(env.authSuccess);
+
+		env.doFilter();
+
+		// still authenticated
+		assertSame(env.authSuccess, SecurityContextHolder.getContext().getAuthentication());
+
+		assertEquals("/added", env.res.getRedirectedUrl());
+
+		verify(env.connectionRepository).addConnection(env.auth.getConnection());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void addConnection_authenticated_failed() throws Exception {
+
+		FilterTestEnv env = new FilterTestEnv("GET", "/auth", null);
+		env.filter.setFilterProcessesUrl(env.req.getRequestURI());
+		env.filter.setPostLoginUrl("/success");
+		env.filter.setConnectionAddedRedirectUrl("/added");
+		env.filter.setConnectionAddingFailureRedirectUrl("/add-failed");
+
+		Connection<?> connection = env.auth.getConnection();
+		ConnectionData data = connection.createData();
+		String userId = "joe";
+
+		ConnectionFactory<Object> factory = mock(MockConnectionFactory.class);
+		when(factory.getProviderId()).thenReturn("mock");
+		when(factory.createConnection(data)).thenReturn((Connection<Object>) connection);
+		env.req.setRequestURI(env.req.getRequestURI() + "/" + factory.getProviderId());
+
+		SocialAuthenticationService<Object> authService = mock(SocialAuthenticationService.class);
+		when(authService.getConnectionCardinality()).thenReturn(ConnectionCardinality.ONE_TO_ONE);
+		when(authService.getConnectionFactory()).thenReturn(factory);
+		when(authService.getAuthToken(env.req, env.res)).thenReturn(env.auth);
+		env.addAuthService(authService);
+
+		when(env.userIdSource.getUserId()).thenReturn(userId);
+
+		// already connected
+		when(env.usersConnectionRepository.findUserIdsConnectedTo(data.getProviderId(), set(data.getProviderUserId()))).thenReturn(set(userId));
+
+		// already authenticated
+		SecurityContextHolder.getContext().setAuthentication(env.authSuccess);
+
+		env.doFilter();
+
+		// still authenticated
+		assertSame(env.authSuccess, SecurityContextHolder.getContext().getAuthentication());
+
+		assertEquals("/add-failed", env.res.getRedirectedUrl());
+
+		verify(env.connectionRepository, times(0)).addConnection(env.auth.getConnection());
+	}
+
 	private static <T> Set<T> empty(Class<T> cls) {
 		return Collections.emptySet();
 	}
@@ -181,6 +269,9 @@ public class SocialAuthenticationFilterTest {
 		private final SocialAuthenticationToken auth;
 		private final SocialAuthenticationToken authSuccess;
 		private final AuthenticationManager authManager;
+		private final UserIdSource userIdSource;
+		private final UsersConnectionRepository usersConnectionRepository;
+		private final ConnectionRepository connectionRepository;
 
 		private FilterTestEnv(String method, String requestURI, String signupUrl) {
 			context = new MockServletContext();
@@ -188,14 +279,16 @@ public class SocialAuthenticationFilterTest {
 			res = new MockHttpServletResponse();
 			chain = new MockFilterChain();
 			authManager = mock(AuthenticationManager.class);
+			userIdSource = mock(UserIdSource.class);
+			usersConnectionRepository = mock(UsersConnectionRepository.class);
+			connectionRepository = mock(ConnectionRepository.class);
 
-			filter = new SocialAuthenticationFilter(authManager, mock(UserIdSource.class), mock(UsersConnectionRepository.class), new SocialAuthenticationServiceRegistry());
+			filter = new SocialAuthenticationFilter(authManager, userIdSource, usersConnectionRepository, new SocialAuthenticationServiceRegistry());
 			filter.setServletContext(context);
 			filter.setRememberMeServices(new NullRememberMeServices());
 			filter.setSignupUrl(signupUrl);
 			
-			ConnectionRepository repo = mock(ConnectionRepository.class);
-			when(filter.getUsersConnectionRepository().createConnectionRepository(Mockito.anyString())).thenReturn(repo);
+			when(filter.getUsersConnectionRepository().createConnectionRepository(Mockito.anyString())).thenReturn(connectionRepository);
 			
 			auth = new SocialAuthenticationToken(DummyConnection.dummy("provider", "user"), null);
 

--- a/spring-social-security/src/test/java/org/springframework/social/security/test/DummyConnection.java
+++ b/spring-social-security/src/test/java/org/springframework/social/security/test/DummyConnection.java
@@ -29,6 +29,8 @@ public class DummyConnection<T> implements Connection<T> {
 	private final ConnectionKey _key;
 	private final T _api;
 
+	private long expireTime = System.currentTimeMillis() + 3_600_000;
+
 	public static DummyConnection<Object> dummy(String provider, String user) {
 		return new DummyConnection<Object>(provider, user, new Object());
 	}
@@ -81,7 +83,7 @@ public class DummyConnection<T> implements Connection<T> {
 
 	public ConnectionData createData() {
 		return new ConnectionData(_key.getProviderId(), _key.getProviderUserId(), getDisplayName(),
-				getProfileUrl(), getImageUrl(), "access_token", "secret", "refresh_token", System.currentTimeMillis() + 10000);
+				getProfileUrl(), getImageUrl(), "access_token", "secret", "refresh_token", expireTime);
 	}
 
 	public static Answer<DummyConnection<Object>> answer() {


### PR DESCRIPTION
Fixes [SOCIAL-406](https://jira.springsource.org/browse/SOCIAL-406) and #95

moved response.sendRedirect(((SocialAuthenticationRedirectException) failed).getRedirectUrl()); out of SocialAuthenticationFailureHandler (thus making it obsolete) and into SocialAuthenticationFilter.attemptAuthentication(..)

use Connection instead of ConnectionData as argument do addConnection(..)