### PR TITLE
ReconnectFilter cant renew the token expire in case of ExpiredAuthorizationException (spring social facebook)

### DIFF
--- a/spring-social-core/src/main/java/org/springframework/social/connect/support/OAuth2Connection.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/support/OAuth2Connection.java
@@ -145,7 +145,7 @@ public class OAuth2Connection<A> extends AbstractConnection<A> {
 		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
 			synchronized (getMonitor()) {
 				if (hasExpired()) {
-					throw new ExpiredAuthorizationException(null); // TODO: Revisit this null as providerId
+					throw new ExpiredAuthorizationException(getKey().getProviderId());
 				}
 				try {
 					return method.invoke(OAuth2Connection.this.api, args);


### PR DESCRIPTION
Passing the provider id to the ExpiredAuthorizationException in a way that the ReconnectFilter can renew the expired token associated to this provider id. In another way the provider id was the string "null" and the session could not be deleted and consequently renewed through ConnectController.

After that the filter removes the old facebook connection and creates a new one through a POST in /connect/facebook?reconnect=true of the ConnectController.
