### PR TITLE
Move UserConnectionRepository tests to an abstract base class

### DIFF
--- a/spring-social-core/src/main/java/org/springframework/social/connect/UsersConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/UsersConnectionRepository.java
@@ -54,4 +54,11 @@ public interface UsersConnectionRepository {
 	 */
 	ConnectionRepository createConnectionRepository(String userId);
 	
+	/**
+	 * The command to execute to create a new local user profile in the event no user id could be mapped to a connection.
+	 * Allows for implicitly creating a user profile from connection data during a provider sign-in attempt.
+	 * Defaults to null, indicating explicit sign-up will be required to complete the provider sign-in attempt.
+	 * @see #findUserIdsWithConnection(Connection)
+	 */
+	void setConnectionSignUp(ConnectionSignUp connectionSignUp);
 }

--- a/spring-social-core/src/main/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepository.java
@@ -60,16 +60,11 @@ public class JdbcUsersConnectionRepository implements UsersConnectionRepository 
 		this.textEncryptor = textEncryptor;
 	}
 
-	/**
-	 * The command to execute to create a new local user profile in the event no user id could be mapped to a connection.
-	 * Allows for implicitly creating a user profile from connection data during a provider sign-in attempt.
-	 * Defaults to null, indicating explicit sign-up will be required to complete the provider sign-in attempt.
-	 * @see #findUserIdsWithConnection(Connection)
-	 */
+	@Override
 	public void setConnectionSignUp(ConnectionSignUp connectionSignUp) {
 		this.connectionSignUp = connectionSignUp;
 	}
-	
+
 	/**
 	 * Sets a table name prefix. This will be prefixed to all the table names before queries are executed. Defaults to "".
 	 * This is can be used to qualify the table name with a schema or to distinguish Spring Social tables from other application tables. 

--- a/spring-social-core/src/main/java/org/springframework/social/connect/mem/InMemoryConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/mem/InMemoryConnectionRepository.java
@@ -17,6 +17,7 @@ package org.springframework.social.connect.mem;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.Map.Entry;
 
 import org.springframework.social.connect.Connection;
@@ -43,7 +44,16 @@ class InMemoryConnectionRepository implements ConnectionRepository {
 	}
 	
 	public MultiValueMap<String, Connection<?>> findAllConnections() {
-		return connections;
+		if (connections.isEmpty()) {
+			MultiValueMap<String, Connection<?>> result = new LinkedMultiValueMap<String, Connection<?>>();
+			Set<String> registeredProviderIds = connectionFactoryLocator.registeredProviderIds();
+			for (String registeredProviderId : registeredProviderIds) {
+				result.put(registeredProviderId, Collections.<Connection<?>>emptyList());
+			}
+			return result;
+		} else {
+			return connections;
+		}
 	}
 
 	public List<Connection<?>> findConnections(String providerId) {

--- a/spring-social-core/src/main/java/org/springframework/social/connect/mem/InMemoryUsersConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/mem/InMemoryUsersConnectionRepository.java
@@ -50,12 +50,7 @@ public class InMemoryUsersConnectionRepository implements UsersConnectionReposit
 		this.connectionRepositories= new HashMap<String, ConnectionRepository>(); 
 	}
 	
-	/**
-	 * The command to execute to create a new local user profile in the event no user id could be mapped to a connection.
-	 * Allows for implicitly creating a user profile from connection data during a provider sign-in attempt.
-	 * Defaults to null, indicating explicit sign-up will be required to complete the provider sign-in attempt.
-	 * @see #findUserIdsWithConnection(Connection)
-	 */
+	@Override
 	public void setConnectionSignUp(ConnectionSignUp connectionSignUp) {
 		this.connectionSignUp = connectionSignUp;
 	}

--- a/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/AbstractUsersConnectionRepositoryTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/AbstractUsersConnectionRepositoryTest.java
@@ -1,24 +1,18 @@
 package org.springframework.social.connect.jdbc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.hamcrest.Matchers.hasItems;
-import java.sql.SQLException;
-import java.sql.Statement;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.sql.DataSource;
-
-import org.h2.Driver;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.jdbc.datasource.embedded.ConnectionProperties;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseConfigurer;
 import org.springframework.social.connect.ApiAdapter;
 import org.springframework.social.connect.Connection;
 import org.springframework.social.connect.ConnectionData;
@@ -594,27 +588,6 @@ public abstract class AbstractUsersConnectionRepositoryTest {
 			public void updateStatus(TestTwitterApi api, String message) {
 			}
 			
-		}
-
-	protected static class MySqlCompatibleH2DatabaseConfigurer implements EmbeddedDatabaseConfigurer {
-			@Override
-			public void shutdown(DataSource dataSource, String databaseName) {
-				try {
-					java.sql.Connection connection = dataSource.getConnection();
-					Statement stmt = connection.createStatement();
-					stmt.execute("SHUTDOWN");
-				}
-				catch (SQLException ex) {
-				}
-			}
-			
-			@Override
-			public void configureConnectionProperties(ConnectionProperties properties, String databaseName) {
-				properties.setDriverClass(Driver.class);
-				properties.setUrl(String.format("jdbc:h2:mem:%s;MODE=MYSQL;DB_CLOSE_DELAY=-1", databaseName));
-				properties.setUsername("sa");
-				properties.setPassword("");
-			}
 		}
 
 	public AbstractUsersConnectionRepositoryTest() {

--- a/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/AbstractUsersConnectionRepositoryTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/AbstractUsersConnectionRepositoryTest.java
@@ -1,0 +1,624 @@
+package org.springframework.social.connect.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.hasItems;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.h2.Driver;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.jdbc.datasource.embedded.ConnectionProperties;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseConfigurer;
+import org.springframework.social.connect.ApiAdapter;
+import org.springframework.social.connect.Connection;
+import org.springframework.social.connect.ConnectionData;
+import org.springframework.social.connect.ConnectionKey;
+import org.springframework.social.connect.ConnectionRepository;
+import org.springframework.social.connect.ConnectionSignUp;
+import org.springframework.social.connect.ConnectionValues;
+import org.springframework.social.connect.DuplicateConnectionException;
+import org.springframework.social.connect.NoSuchConnectionException;
+import org.springframework.social.connect.NotConnectedException;
+import org.springframework.social.connect.UserProfile;
+import org.springframework.social.connect.UserProfileBuilder;
+import org.springframework.social.connect.UsersConnectionRepository;
+import org.springframework.social.connect.support.ConnectionFactoryRegistry;
+import org.springframework.social.connect.support.OAuth1ConnectionFactory;
+import org.springframework.social.connect.support.OAuth2ConnectionFactory;
+import org.springframework.social.oauth1.OAuth1Operations;
+import org.springframework.social.oauth1.OAuth1ServiceProvider;
+import org.springframework.social.oauth2.AccessGrant;
+import org.springframework.social.oauth2.GrantType;
+import org.springframework.social.oauth2.OAuth2Operations;
+import org.springframework.social.oauth2.OAuth2Parameters;
+import org.springframework.social.oauth2.OAuth2ServiceProvider;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+public abstract class AbstractUsersConnectionRepositoryTest {
+
+	protected static final String TWITTER_CONNECTION_1_PROVIDER_ID = "1";
+	protected static final String FACEBOOK_CONNECTION_1_PROVIDER_ID = "9";
+	protected static final String FACEBOOK_CONNECTION_2_PROVIDER_ID = "10";
+	protected static final String FACEBOOK_CONNECTION_3_PROVIDER_ID = "11";
+	
+	protected static final ConnectionData TWITTER_DATA =
+			new ConnectionData("twitter", TWITTER_CONNECTION_1_PROVIDER_ID, "@kdonald", "http://twitter.com/kdonald", "http://twitter.com/kdonald/picture", "123456789", "987654321", "refresh_token", System.currentTimeMillis() + 3600000);
+	protected static final ConnectionData FACEBOOK_DATA_1 =
+			new ConnectionData("facebook", FACEBOOK_CONNECTION_1_PROVIDER_ID, null, null, null, "234567890", null, "345678901", System.currentTimeMillis() + 3600000);
+	protected static final ConnectionData FACEBOOK_DATA_2 =
+			new ConnectionData("facebook", FACEBOOK_CONNECTION_2_PROVIDER_ID, null, null, null, "456789012", null, "56789012", System.currentTimeMillis() + 3600000);
+	protected static final ConnectionData FACEBOOK_DATA_3 =
+			new ConnectionData("facebook", FACEBOOK_CONNECTION_3_PROVIDER_ID, null, null, null, "234567890", null, "345678901", System.currentTimeMillis() + 3600000);
+
+	
+	protected static class TestFacebookConnectionFactory extends OAuth2ConnectionFactory<TestFacebookApi> {
+	
+			public TestFacebookConnectionFactory() {
+				super("facebook", new TestFacebookServiceProvider(), new TestFacebookApiAdapter());
+			}
+			
+		}
+
+	private TestFacebookConnectionFactory facebookConnectionFactory;
+	private TestTwitterConnectionFactory twitterConnectionFactory;
+	private ConnectionFactoryRegistry connectionFactoryRegistry = new ConnectionFactoryRegistry();
+	
+	protected abstract void insertTwitterConnection();
+	protected abstract void insertFacebookConnection1();
+	protected abstract void insertFacebookConnection2();
+	protected abstract void insertFacebookConnection3();
+	protected abstract void insertFacebookConnectionSameFacebookUser();
+	
+	protected abstract UsersConnectionRepository getUsersConnectionRepository();
+	protected abstract ConnectionRepository getConnectionRepository();
+	
+	protected TestFacebookConnectionFactory getFacebookConnectionFactory() {
+		return facebookConnectionFactory;
+	}
+	
+	public TestTwitterConnectionFactory getTwitterConnectionFactory() {
+		return twitterConnectionFactory;
+	}
+	
+	public ConnectionFactoryRegistry getConnectionFactoryRegistry() {
+		return this.connectionFactoryRegistry;
+	}
+	
+	@Before
+	public void setUpConnectionFactory() {
+		facebookConnectionFactory = new TestFacebookConnectionFactory();
+		twitterConnectionFactory  = new TestTwitterConnectionFactory();
+		connectionFactoryRegistry = new ConnectionFactoryRegistry();
+		connectionFactoryRegistry.addConnectionFactory(facebookConnectionFactory);
+		connectionFactoryRegistry.addConnectionFactory(twitterConnectionFactory);
+	}
+	
+	@Test
+	public void findUserIdWithConnection() {
+		insertFacebookConnection1();
+		List<String> userIds = getUsersConnectionRepository().findUserIdsWithConnection(getConnectionRepository().getPrimaryConnection(TestFacebookApi.class));
+		assertEquals(TWITTER_CONNECTION_1_PROVIDER_ID, userIds.get(0));
+	}
+
+	@Test
+	public void findUserIdWithConnectionNoSuchConnection() {
+		Connection<TestFacebookApi> connection = getFacebookConnectionFactory().createConnection(new AccessGrant("12345"));
+		assertEquals(0, getUsersConnectionRepository().findUserIdsWithConnection(connection).size());
+	}
+
+	@Test
+	public void findUserIdWithConnectionMultipleConnectionsToSameProviderUser() {
+		insertFacebookConnection1();
+		insertFacebookConnectionSameFacebookUser();
+		List<String> localUserIds = getUsersConnectionRepository().findUserIdsWithConnection(getConnectionRepository().getPrimaryConnection(TestFacebookApi.class));
+		assertEquals(2, localUserIds.size());
+		assertThat(localUserIds, hasItems("1", "2"));
+	}
+
+	@Test
+	public void findUserIdWithConnectionNoConnection_withWorkingConnectionSignUp() {		
+		Connection<TestFacebookApi> connection = facebookConnectionFactory.createConnection(new AccessGrant("12345"));
+		getUsersConnectionRepository().setConnectionSignUp(new ConnectionSignUp() {
+			@Override
+			public String execute(Connection<?> connection) {
+				return "batman";
+			}
+		});
+		List<String> userIds = getUsersConnectionRepository().findUserIdsWithConnection(connection);
+		assertEquals(1, userIds.size());
+		assertEquals("batman", userIds.get(0));
+	}
+
+	@Test
+	public void findUserIdWithConnectionNoConnection_withConnectionSignUpReturningNull() {		
+		Connection<TestFacebookApi> connection = facebookConnectionFactory.createConnection(new AccessGrant("12345"));
+		getUsersConnectionRepository().setConnectionSignUp(new ConnectionSignUp() {
+			@Override
+			public String execute(Connection<?> connection) {
+				return null;
+			}
+		});
+		List<String> userIds = getUsersConnectionRepository().findUserIdsWithConnection(connection);
+		assertEquals(0, userIds.size());
+	}
+
+	@Test
+	public void findUserIdsConnectedTo() {
+		insertFacebookConnection1();
+		insertFacebookConnection3();
+		Set<String> localUserIds = getUsersConnectionRepository().findUserIdsConnectedTo("facebook",
+				new HashSet<String>(Arrays.asList(FACEBOOK_CONNECTION_1_PROVIDER_ID, FACEBOOK_CONNECTION_3_PROVIDER_ID)));
+		assertEquals(2, localUserIds.size());
+		assertThat(localUserIds, hasItems("1", "2"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findAllConnections() {
+		insertTwitterConnection();
+		insertFacebookConnection1();
+		MultiValueMap<String, Connection<?>> connections = getConnectionRepository().findAllConnections();
+		assertEquals(2, connections.size());
+		Connection<TestFacebookApi> facebook = (Connection<TestFacebookApi>) connections.getFirst("facebook");
+		assertFacebookConnection(facebook);
+		Connection<TestTwitterApi> twitter = (Connection<TestTwitterApi>) connections.getFirst("twitter");
+		assertTwitterConnection(twitter);
+	}
+
+	@Test
+	public void findAllConnectionsMultipleConnectionResults() {
+		insertTwitterConnection();
+		insertFacebookConnection1();
+		insertFacebookConnection2();
+		MultiValueMap<String, Connection<?>> connections = getConnectionRepository().findAllConnections();
+		assertEquals(2, connections.size());
+		assertEquals(2, connections.get("facebook").size());
+		assertEquals(1, connections.get("twitter").size());
+	}
+
+	@Test
+	public void findAllConnectionsEmptyResult() {
+		MultiValueMap<String, Connection<?>> connections = getConnectionRepository().findAllConnections();
+		assertEquals(2, connections.size());
+		assertEquals(0, connections.get("facebook").size());
+		assertEquals(0, connections.get("twitter").size());		
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findConnectionsByProviderId() {
+		insertTwitterConnection();
+		List<Connection<?>> connections = getConnectionRepository().findConnections("twitter");
+		assertEquals(1, connections.size());
+		assertTwitterConnection((Connection<TestTwitterApi>) connections.get(0));
+	}
+
+	@Test
+	public void findConnectionsByProviderIdEmptyResult() {
+		assertTrue(getConnectionRepository().findConnections("facebook").isEmpty());
+	}
+
+	@Test
+	public void findConnectionsByApi() {
+		insertFacebookConnection1();
+		insertFacebookConnection2();
+		List<Connection<TestFacebookApi>> connections = getConnectionRepository().findConnections(TestFacebookApi.class);
+		assertEquals(2, connections.size());
+		assertFacebookConnection(connections.get(0));
+	}
+
+	@Test
+	public void findConnectionsByApiEmptyResult() {
+		assertTrue(getConnectionRepository().findConnections(TestFacebookApi.class).isEmpty());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findConnectionsToUsers() {
+		insertTwitterConnection();
+		insertFacebookConnection2();
+		insertFacebookConnection1();
+		MultiValueMap<String, String> providerUsers = new LinkedMultiValueMap<String, String>();
+		providerUsers.add("twitter", TWITTER_CONNECTION_1_PROVIDER_ID);
+		providerUsers.add("facebook", FACEBOOK_CONNECTION_2_PROVIDER_ID);
+		providerUsers.add("facebook", FACEBOOK_CONNECTION_1_PROVIDER_ID);
+		MultiValueMap<String, Connection<?>> connectionsForUsers = getConnectionRepository().findConnectionsToUsers(providerUsers);
+		assertEquals(2, connectionsForUsers.size());
+		assertEquals(FACEBOOK_CONNECTION_2_PROVIDER_ID, connectionsForUsers.getFirst("facebook").getKey().getProviderUserId());
+		assertFacebookConnection((Connection<TestFacebookApi>) connectionsForUsers.get("facebook").get(1));
+		assertTwitterConnection((Connection<TestTwitterApi>) connectionsForUsers.getFirst("twitter"));
+	}
+
+	@Test
+	public void findConnectionsToUsersEmptyResult() {
+		MultiValueMap<String, String> providerUsers = new LinkedMultiValueMap<String, String>();
+		providerUsers.add("facebook", FACEBOOK_CONNECTION_1_PROVIDER_ID);
+		assertTrue(getConnectionRepository().findConnectionsToUsers(providerUsers).isEmpty());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void findConnectionsToUsersEmptyInput() {
+		MultiValueMap<String, String> providerUsers = new LinkedMultiValueMap<String, String>();
+		getConnectionRepository().findConnectionsToUsers(providerUsers);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void findConnectionByKey() {
+		insertFacebookConnection1();
+		assertFacebookConnection((Connection<TestFacebookApi>) getConnectionRepository().getConnection(new ConnectionKey("facebook", "9")));
+	}
+
+	@Test(expected = NoSuchConnectionException.class)
+	public void findConnectionByKeyNoSuchConnection() {
+		getConnectionRepository().getConnection(new ConnectionKey("facebook", "bogus"));
+	}
+
+	@Test
+	public void findConnectionByApiToUser() {
+		insertFacebookConnection1();
+		insertFacebookConnection2();	
+		assertFacebookConnection(getConnectionRepository().getConnection(TestFacebookApi.class, FACEBOOK_CONNECTION_1_PROVIDER_ID));
+		assertEquals(FACEBOOK_CONNECTION_2_PROVIDER_ID, getConnectionRepository().getConnection(TestFacebookApi.class, FACEBOOK_CONNECTION_2_PROVIDER_ID).getKey().getProviderUserId());
+	}
+
+	@Test(expected = NoSuchConnectionException.class)
+	public void findConnectionByApiToUserNoSuchConnection() {
+		assertFacebookConnection(getConnectionRepository().getConnection(TestFacebookApi.class, FACEBOOK_CONNECTION_1_PROVIDER_ID));
+	}
+
+	@Test
+	public void findPrimaryConnection() {
+		insertFacebookConnection1();
+		assertFacebookConnection(getConnectionRepository().getPrimaryConnection(TestFacebookApi.class));
+	}
+
+	@Test
+	public void findPrimaryConnectionSelectFromMultipleByRank() {
+		insertFacebookConnection1();
+		insertFacebookConnection2();
+		assertFacebookConnection(getConnectionRepository().getPrimaryConnection(TestFacebookApi.class));
+	}
+
+	@Test(expected = NotConnectedException.class)
+	public void findPrimaryConnectionNotConnected() {
+		getConnectionRepository().getPrimaryConnection(TestFacebookApi.class);
+	}
+
+	@Test
+	public void removeConnections() {
+		insertFacebookConnection1();
+		insertFacebookConnection2();
+		assertEquals(2, getConnectionRepository().findConnections("facebook").size());
+		getConnectionRepository().removeConnections("facebook");
+		assertEquals(0, getConnectionRepository().findConnections("facebook").size());
+	}
+
+	@Test
+	public void removeConnectionsToProviderNoOp() {
+		getConnectionRepository().removeConnections("twitter");
+	}
+
+	@Test
+	public void removeConnection() {
+		insertFacebookConnection1();
+		insertFacebookConnection2();
+		assertEquals(2, getConnectionRepository().findConnections("facebook").size());
+		getConnectionRepository().removeConnection(new ConnectionKey("facebook", FACEBOOK_CONNECTION_1_PROVIDER_ID));
+		assertEquals(1, getConnectionRepository().findConnections("facebook").size());		
+	}
+
+	@Test
+	public void removeConnectionNoOp() {
+		getConnectionRepository().removeConnection(new ConnectionKey("facebook", "1111111111"));
+	}
+
+	@Test
+	public void addConnection() {
+		Connection<TestFacebookApi> connection = facebookConnectionFactory.createConnection(new AccessGrant("123456789", null, "987654321", 3600L));
+		getConnectionRepository().addConnection(connection);
+		Connection<TestFacebookApi> restoredConnection = getConnectionRepository().getPrimaryConnection(TestFacebookApi.class);
+		assertEquals(connection, restoredConnection);	
+		assertNewConnection(restoredConnection);
+	}
+
+	@Test(expected = DuplicateConnectionException.class)
+	public void addConnectionDuplicate() {
+		Connection<TestFacebookApi> connection = facebookConnectionFactory.createConnection(new AccessGrant("123456789", null, "987654321", 3600L));
+		getConnectionRepository().addConnection(connection);
+		getConnectionRepository().addConnection(connection);
+	}
+
+	@Test
+	public void updateConnectionProfileFields() {
+		insertTwitterConnection();
+		Connection<TestTwitterApi> twitter = getConnectionRepository().getPrimaryConnection(TestTwitterApi.class);
+		assertEquals("http://twitter.com/kdonald/picture", twitter.getImageUrl());
+		twitter.sync();
+		assertEquals("http://twitter.com/kdonald/a_new_picture", twitter.getImageUrl());
+		getConnectionRepository().updateConnection(twitter);
+		Connection<TestTwitterApi> twitter2 = getConnectionRepository().getPrimaryConnection(TestTwitterApi.class);
+		assertEquals("http://twitter.com/kdonald/a_new_picture", twitter2.getImageUrl());
+	}
+
+	@Test
+	public void updateConnectionAccessFields() {
+		insertFacebookConnection1();
+		Connection<TestFacebookApi> facebook = getConnectionRepository().getPrimaryConnection(TestFacebookApi.class);
+		assertEquals("234567890", facebook.getApi().getAccessToken());
+		facebook.refresh();
+		getConnectionRepository().updateConnection(facebook);
+		Connection<TestFacebookApi> facebook2 = getConnectionRepository().getPrimaryConnection(TestFacebookApi.class);
+		assertEquals("765432109", facebook2.getApi().getAccessToken());
+		ConnectionData data = facebook.createData();
+		assertEquals("654321098", data.getRefreshToken());
+	}
+
+	@Test
+	public void findPrimaryConnection_afterRemove() {
+		insertFacebookConnection1();
+		insertFacebookConnection2();    
+		// 9 is the providerUserId of the first Facebook connection
+		getConnectionRepository().removeConnection(new ConnectionKey("facebook", FACEBOOK_CONNECTION_1_PROVIDER_ID));
+		assertEquals(1, getConnectionRepository().findConnections(TestFacebookApi.class).size());
+		assertNotNull(getConnectionRepository().findPrimaryConnection(TestFacebookApi.class));
+	}
+
+	protected String getTablePrefix() {
+		return "";
+	}
+
+	protected String getSchemaSql() {
+		return "JdbcUsersConnectionRepository.sql";
+	}
+
+	private void assertNewConnection(Connection<TestFacebookApi> connection) {
+		assertEquals("facebook", connection.getKey().getProviderId());
+		assertEquals(FACEBOOK_CONNECTION_1_PROVIDER_ID, connection.getKey().getProviderUserId());
+		assertEquals("Keith Donald", connection.getDisplayName());
+		assertEquals("http://facebook.com/keith.donald", connection.getProfileUrl());
+		assertEquals("http://facebook.com/keith.donald/picture", connection.getImageUrl());
+		assertTrue(connection.test());
+		TestFacebookApi api = connection.getApi();
+		assertNotNull(api);
+		assertEquals("123456789", api.getAccessToken());
+		assertEquals("123456789", connection.createData().getAccessToken());
+		assertEquals("987654321", connection.createData().getRefreshToken());
+	}
+
+	private void assertTwitterConnection(Connection<TestTwitterApi> twitter) {
+		assertEquals(new ConnectionKey("twitter", TWITTER_CONNECTION_1_PROVIDER_ID), twitter.getKey());
+		assertEquals("@kdonald", twitter.getDisplayName());
+		assertEquals("http://twitter.com/kdonald", twitter.getProfileUrl());
+		assertEquals("http://twitter.com/kdonald/picture", twitter.getImageUrl());
+		TestTwitterApi twitterApi = twitter.getApi();
+		assertEquals("123456789", twitterApi.getAccessToken());		
+		assertEquals("987654321", twitterApi.getSecret());
+		twitter.sync();
+		assertEquals("http://twitter.com/kdonald/a_new_picture", twitter.getImageUrl());
+	}
+
+	private void assertFacebookConnection(Connection<TestFacebookApi> facebook) {
+		assertEquals(new ConnectionKey("facebook", FACEBOOK_CONNECTION_1_PROVIDER_ID), facebook.getKey());
+		assertEquals(null, facebook.getDisplayName());
+		assertEquals(null, facebook.getProfileUrl());
+		assertEquals(null, facebook.getImageUrl());
+		TestFacebookApi facebookApi = facebook.getApi();
+		assertEquals("234567890", facebookApi.getAccessToken());
+		facebook.sync();
+		assertEquals("Keith Donald", facebook.getDisplayName());
+		assertEquals("http://facebook.com/keith.donald", facebook.getProfileUrl());
+		assertEquals("http://facebook.com/keith.donald/picture", facebook.getImageUrl());		
+	}
+
+	protected static class TestFacebookServiceProvider implements OAuth2ServiceProvider<TestFacebookApi> {
+	
+			@Override
+			public OAuth2Operations getOAuthOperations() {
+				return new OAuth2Operations() {
+					@Override
+					public String buildAuthorizeUrl(GrantType grantType, OAuth2Parameters params) {
+						return null;
+					}
+					@Override
+					public String buildAuthenticateUrl(GrantType grantType, OAuth2Parameters params) {
+						return null;
+					}
+					@Override
+					public String buildAuthorizeUrl(OAuth2Parameters params) {
+						return null;
+					}
+					@Override
+					public String buildAuthenticateUrl(OAuth2Parameters params) {
+						return null;
+					}
+					@Override
+					public AccessGrant exchangeForAccess(String authorizationGrant, String redirectUri, MultiValueMap<String, String> additionalParameters) {
+						return null;
+					}				
+					@Override
+					public AccessGrant exchangeCredentialsForAccess(String username, String password, MultiValueMap<String, String> additionalParameters) {
+						return null;
+					}
+					@Override
+					public AccessGrant refreshAccess(String refreshToken, MultiValueMap<String, String> additionalParameters) {
+						return new AccessGrant("765432109", "read", "654321098", 3600L);
+					}
+					@Override
+					public AccessGrant refreshAccess(String refreshToken, String scope, MultiValueMap<String, String> additionalParameters) {
+						return new AccessGrant("765432109", "read", "654321098", 3600L);
+					}
+					@Override
+					public AccessGrant authenticateClient() {
+						return null;
+					}
+					@Override
+					public AccessGrant authenticateClient(String scope) {
+						return null;
+					}
+	            };
+			}
+	
+			@Override
+			public TestFacebookApi getApi(final String accessToken) {
+				return new TestFacebookApi() {
+					@Override
+					public String getAccessToken() {
+						return accessToken;
+					}
+				};
+			}
+			
+		}
+
+	public interface TestFacebookApi {
+		
+		String getAccessToken();
+		
+	}
+
+	protected static class TestFacebookApiAdapter implements ApiAdapter<TestFacebookApi> {
+	
+			private final String accountId = FACEBOOK_CONNECTION_1_PROVIDER_ID;
+			
+			private final String name = "Keith Donald";
+			
+			private final String profileUrl = "http://facebook.com/keith.donald";
+			
+			private final String profilePictureUrl = "http://facebook.com/keith.donald/picture";
+			
+			@Override
+			public boolean test(TestFacebookApi api) {
+				return true;
+			}
+	
+			@Override
+			public void setConnectionValues(TestFacebookApi api, ConnectionValues values) {
+				values.setProviderUserId(accountId);
+				values.setDisplayName(name);
+				values.setProfileUrl(profileUrl);
+				values.setImageUrl(profilePictureUrl);
+			}
+	
+			@Override
+			public UserProfile fetchUserProfile(TestFacebookApi api) {
+				return new UserProfileBuilder().setName(name).setEmail("keith@interface21.com").setUsername("Keith.Donald").build();
+			}
+	
+			@Override
+			public void updateStatus(TestFacebookApi api, String message) {
+				
+			}
+			
+		}
+
+	protected static class TestTwitterConnectionFactory extends OAuth1ConnectionFactory<TestTwitterApi> {
+	
+			public TestTwitterConnectionFactory() {
+				super("twitter", new TestTwitterServiceProvider(), new TestTwitterApiAdapter());
+			}
+			
+		}
+
+	protected static class TestTwitterServiceProvider implements OAuth1ServiceProvider<TestTwitterApi> {
+	
+			@Override
+			public OAuth1Operations getOAuthOperations() {
+				return null;
+			}
+	
+			@Override
+			public TestTwitterApi getApi(final String accessToken, final String secret) {
+				return new TestTwitterApi() {
+					@Override
+					public String getAccessToken() {
+						return accessToken;
+					}
+					@Override
+					public String getSecret() {
+						return secret;
+					}
+				};
+			}
+			
+		}
+
+	public interface TestTwitterApi {
+		
+		String getAccessToken();
+		
+		String getSecret();
+		
+	}
+
+	protected static class TestTwitterApiAdapter implements ApiAdapter<TestTwitterApi> {
+	
+			private final String accountId = TWITTER_CONNECTION_1_PROVIDER_ID;
+			
+			private final String name = "@kdonald";
+			
+			private final String profileUrl = "http://twitter.com/kdonald";
+			
+			private final String profilePictureUrl = "http://twitter.com/kdonald/a_new_picture";
+			
+			@Override
+			public boolean test(TestTwitterApi api) {
+				return true;
+			}
+	
+			@Override
+			public void setConnectionValues(TestTwitterApi api, ConnectionValues values) {
+				values.setProviderUserId(accountId);
+				values.setDisplayName(name);
+				values.setProfileUrl(profileUrl);
+				values.setImageUrl(profilePictureUrl);
+			}
+	
+			@Override
+			public UserProfile fetchUserProfile(TestTwitterApi api) {
+				return new UserProfileBuilder().setName(name).setUsername("kdonald").build();			
+			}
+			
+			@Override
+			public void updateStatus(TestTwitterApi api, String message) {
+			}
+			
+		}
+
+	protected static class MySqlCompatibleH2DatabaseConfigurer implements EmbeddedDatabaseConfigurer {
+			@Override
+			public void shutdown(DataSource dataSource, String databaseName) {
+				try {
+					java.sql.Connection connection = dataSource.getConnection();
+					Statement stmt = connection.createStatement();
+					stmt.execute("SHUTDOWN");
+				}
+				catch (SQLException ex) {
+				}
+			}
+			
+			@Override
+			public void configureConnectionProperties(ConnectionProperties properties, String databaseName) {
+				properties.setDriverClass(Driver.class);
+				properties.setUrl(String.format("jdbc:h2:mem:%s;MODE=MYSQL;DB_CLOSE_DELAY=-1", databaseName));
+				properties.setUsername("sa");
+				properties.setPassword("");
+			}
+		}
+
+	public AbstractUsersConnectionRepositoryTest() {
+		super();
+	}
+
+}

--- a/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepositoryTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepositoryTest.java
@@ -15,70 +15,42 @@
  */
 package org.springframework.social.connect.jdbc;
 
-import static org.junit.Assert.*;
-
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import javax.sql.DataSource;
-
-import org.h2.Driver;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.datasource.embedded.ConnectionProperties;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseConfigurer;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseFactory;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.security.crypto.encrypt.Encryptors;
-import org.springframework.social.connect.ApiAdapter;
-import org.springframework.social.connect.Connection;
 import org.springframework.social.connect.ConnectionData;
-import org.springframework.social.connect.ConnectionKey;
 import org.springframework.social.connect.ConnectionRepository;
-import org.springframework.social.connect.ConnectionSignUp;
-import org.springframework.social.connect.ConnectionValues;
-import org.springframework.social.connect.DuplicateConnectionException;
-import org.springframework.social.connect.NoSuchConnectionException;
-import org.springframework.social.connect.NotConnectedException;
-import org.springframework.social.connect.UserProfile;
-import org.springframework.social.connect.UserProfileBuilder;
-import org.springframework.social.connect.support.ConnectionFactoryRegistry;
-import org.springframework.social.connect.support.OAuth1ConnectionFactory;
-import org.springframework.social.connect.support.OAuth2ConnectionFactory;
-import org.springframework.social.oauth1.OAuth1Operations;
-import org.springframework.social.oauth1.OAuth1ServiceProvider;
-import org.springframework.social.oauth2.AccessGrant;
-import org.springframework.social.oauth2.GrantType;
-import org.springframework.social.oauth2.OAuth2Operations;
-import org.springframework.social.oauth2.OAuth2Parameters;
-import org.springframework.social.oauth2.OAuth2ServiceProvider;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
+import org.springframework.social.connect.UsersConnectionRepository;
 
-public class JdbcUsersConnectionRepositoryTest {
+public class JdbcUsersConnectionRepositoryTest extends AbstractUsersConnectionRepositoryTest {
 
 	private EmbeddedDatabase database;
 
 	private boolean testMySqlCompatiblity;
 	
-	private ConnectionFactoryRegistry connectionFactoryRegistry;
-	
-	private TestFacebookConnectionFactory connectionFactory;
-	
-	private JdbcTemplate dataAccessor;
+	JdbcTemplate dataAccessor;
 
-	private JdbcUsersConnectionRepository usersConnectionRepository;
+	JdbcUsersConnectionRepository usersConnectionRepository;
 
-	private ConnectionRepository connectionRepository;
+	ConnectionRepository connectionRepository;
+
+
+	@Override
+	protected UsersConnectionRepository getUsersConnectionRepository() {
+		return usersConnectionRepository;
+	}
+
+	@Override
+	protected ConnectionRepository getConnectionRepository() {
+		return connectionRepository;
+	}
 
 	@Before
 	public void setUp() {
@@ -93,10 +65,7 @@ public class JdbcUsersConnectionRepositoryTest {
 		factory.setDatabasePopulator(populator);
 		database = factory.getDatabase();
 		dataAccessor = new JdbcTemplate(database);
-		connectionFactoryRegistry = new ConnectionFactoryRegistry();
-		connectionFactory = new TestFacebookConnectionFactory();
-		connectionFactoryRegistry.addConnectionFactory(connectionFactory);
-		usersConnectionRepository = new JdbcUsersConnectionRepository(database, connectionFactoryRegistry, Encryptors.noOpText());
+		usersConnectionRepository = new JdbcUsersConnectionRepository(database, getConnectionFactoryRegistry(), Encryptors.noOpText());
 		if (!getTablePrefix().equals("")) {
 			usersConnectionRepository.setTablePrefix(getTablePrefix());
 		}
@@ -109,540 +78,45 @@ public class JdbcUsersConnectionRepositoryTest {
 			database.shutdown();
 		}
 	}
-
-	@Test
-	public void findUserIdWithConnection() {
-		insertFacebookConnection();
-		List<String> userIds = usersConnectionRepository.findUserIdsWithConnection(connectionRepository.getPrimaryConnection(TestFacebookApi.class));
-		assertEquals("1", userIds.get(0));
+	
+	protected void insertFooConnection() {
+		dataAccessor.update("insert into " + getTablePrefix() + "UserConnection (userId, providerId, providerUserId, rank, displayName, profileUrl, imageUrl, accessToken, secret, refreshToken, expireTime) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+				"1", "foo", "123", 1, "james", null, null, "234", "123", null, System.currentTimeMillis() + 3600000);
 	}
 	
-	@Test
-	public void findUserIdWithConnectionNoSuchConnection() {
-		Connection<TestFacebookApi> connection = connectionFactory.createConnection(new AccessGrant("12345"));
-		assertEquals(0, usersConnectionRepository.findUserIdsWithConnection(connection).size());
-	}
-
-	@Test
-	public void findUserIdWithConnectionMultipleConnectionsToSameProviderUser() {
-		insertFacebookConnection();
-		insertFacebookConnectionSameFacebookUser();
-		List<String> localUserIds = usersConnectionRepository.findUserIdsWithConnection(connectionRepository.getPrimaryConnection(TestFacebookApi.class));
-		assertEquals(2, localUserIds.size());
-		assertEquals("1", localUserIds.get(0));
-		assertEquals("2", localUserIds.get(1));
-	}
-
-	@Test
-	public void findUserIdWithConnectionNoConnection_withWorkingConnectionSignUp() {		
-		Connection<TestFacebookApi> connection = connectionFactory.createConnection(new AccessGrant("12345"));
-		usersConnectionRepository.setConnectionSignUp(new ConnectionSignUp() {
-			public String execute(Connection<?> connection) {
-				return "batman";
-			}
-		});
-		List<String> userIds = usersConnectionRepository.findUserIdsWithConnection(connection);
-		assertEquals(1, userIds.size());
-		assertEquals("batman", userIds.get(0));
+	private void insertConnection(ConnectionData data, String userId, int rank) {
+		dataAccessor.update("insert into " + getTablePrefix() + "UserConnection (userId, providerId, providerUserId, rank, displayName, profileUrl, imageUrl, accessToken, secret, refreshToken, expireTime) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+				userId, data.getProviderId(), data.getProviderUserId(), rank, data.getDisplayName(), data.getProfileUrl(), data.getImageUrl(), data.getAccessToken(), data.getSecret(), data.getRefreshToken(), System.currentTimeMillis() + 3600000);
 	}
 	
-	@Test
-	public void findUserIdWithConnectionNoConnection_withConnectionSignUpReturningNull() {		
-		Connection<TestFacebookApi> connection = connectionFactory.createConnection(new AccessGrant("12345"));
-		usersConnectionRepository.setConnectionSignUp(new ConnectionSignUp() {
-			public String execute(Connection<?> connection) {
-				return null;
-			}
-		});
-		List<String> userIds = usersConnectionRepository.findUserIdsWithConnection(connection);
-		assertEquals(0, userIds.size());
+	@Override
+	protected void insertTwitterConnection() {
+		insertConnection(TWITTER_DATA, "1", 1);
 	}
 
-	@Test
-	public void findUserIdsConnectedTo() {
-		insertFacebookConnection();
-		insertFacebookConnection3();
-		Set<String> localUserIds = usersConnectionRepository.findUserIdsConnectedTo("facebook", new HashSet<String>(Arrays.asList("9", "11")));
-		assertEquals(2, localUserIds.size());
-		assertTrue(localUserIds.contains("1"));
-		assertTrue(localUserIds.contains("2"));		
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void findAllConnections() {
-		connectionFactoryRegistry.addConnectionFactory(new TestTwitterConnectionFactory());
-		insertTwitterConnection();
-		insertFacebookConnection();
-		MultiValueMap<String, Connection<?>> connections = connectionRepository.findAllConnections();
-		assertEquals(2, connections.size());
-		Connection<TestFacebookApi> facebook = (Connection<TestFacebookApi>) connections.getFirst("facebook");
-		assertFacebookConnection(facebook);
-		Connection<TestTwitterApi> twitter = (Connection<TestTwitterApi>) connections.getFirst("twitter");
-		assertTwitterConnection(twitter);
+	@Override
+	protected void insertFacebookConnection1() {
+		insertConnection(FACEBOOK_DATA_1, "1", 1);
 	}
 	
-	@Test
-	public void findAllConnectionsMultipleConnectionResults() {
-		connectionFactoryRegistry.addConnectionFactory(new TestTwitterConnectionFactory());
-		insertTwitterConnection();
-		insertFacebookConnection();
-		insertFacebookConnection2();
-		MultiValueMap<String, Connection<?>> connections = connectionRepository.findAllConnections();
-		assertEquals(2, connections.size());
-		assertEquals(2, connections.get("facebook").size());
-		assertEquals(1, connections.get("twitter").size());
+	@Override
+	protected void insertFacebookConnection2() {
+		insertConnection(FACEBOOK_DATA_2, "1", 2);
 	}
 
-	@Test
-	public void findAllConnectionsEmptyResult() {
-		connectionFactoryRegistry.addConnectionFactory(new TestTwitterConnectionFactory());
-		MultiValueMap<String, Connection<?>> connections = connectionRepository.findAllConnections();
-		assertEquals(2, connections.size());
-		assertEquals(0, connections.get("facebook").size());
-		assertEquals(0, connections.get("twitter").size());		
+	@Override
+	protected void insertFacebookConnection3() {
+		insertConnection(FACEBOOK_DATA_3, "2", 2);
 	}
 
-	@Test(expected=IllegalArgumentException.class)
+	@Override
+	protected void insertFacebookConnectionSameFacebookUser() {
+		insertConnection(FACEBOOK_DATA_1, "2", 1);
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
 	public void noSuchConnectionFactory() {
-		insertTwitterConnection();
-		connectionRepository.findAllConnections();	
+		insertFooConnection();
+		getConnectionRepository().findAllConnections();	
 	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void findConnectionsByProviderId() {
-		connectionFactoryRegistry.addConnectionFactory(new TestTwitterConnectionFactory());
-		insertTwitterConnection();
-		List<Connection<?>> connections = connectionRepository.findConnections("twitter");
-		assertEquals(1, connections.size());
-		assertTwitterConnection((Connection<TestTwitterApi>) connections.get(0));
-	}
-	
-	@Test
-	public void findConnectionsByProviderIdEmptyResult() {
-		assertTrue(connectionRepository.findConnections("facebook").isEmpty());
-	}
-
-	@Test
-	public void findConnectionsByApi() {
-		insertFacebookConnection();
-		insertFacebookConnection2();
-		List<Connection<TestFacebookApi>> connections = connectionRepository.findConnections(TestFacebookApi.class);
-		assertEquals(2, connections.size());
-		assertFacebookConnection(connections.get(0));
-	}
-	
-	@Test
-	public void findConnectionsByApiEmptyResult() {
-		assertTrue(connectionRepository.findConnections(TestFacebookApi.class).isEmpty());
-	}
-	
-	@Test
-	@SuppressWarnings("unchecked")
-	public void findConnectionsToUsers() {
-		connectionFactoryRegistry.addConnectionFactory(new TestTwitterConnectionFactory());
-		insertTwitterConnection();
-		insertFacebookConnection();
-		insertFacebookConnection2();
-		MultiValueMap<String, String> providerUsers = new LinkedMultiValueMap<String, String>();
-		providerUsers.add("facebook", "10");
-		providerUsers.add("facebook", "9");
-		providerUsers.add("twitter", "1");
-		MultiValueMap<String, Connection<?>> connectionsForUsers = connectionRepository.findConnectionsToUsers(providerUsers);
-		assertEquals(2, connectionsForUsers.size());
-		assertEquals("10", connectionsForUsers.getFirst("facebook").getKey().getProviderUserId());
-		assertFacebookConnection((Connection<TestFacebookApi>) connectionsForUsers.get("facebook").get(1));
-		assertTwitterConnection((Connection<TestTwitterApi>) connectionsForUsers.getFirst("twitter"));
-	}
-	
-	@Test
-	public void findConnectionsToUsersEmptyResult() {
-		MultiValueMap<String, String> providerUsers = new LinkedMultiValueMap<String, String>();
-		providerUsers.add("facebook", "1");
-		assertTrue(connectionRepository.findConnectionsToUsers(providerUsers).isEmpty());
-	}
-	
-	@Test(expected=IllegalArgumentException.class)
-	public void findConnectionsToUsersEmptyInput() {
-		MultiValueMap<String, String> providerUsers = new LinkedMultiValueMap<String, String>();
-		connectionRepository.findConnectionsToUsers(providerUsers);
-	}
-	
-	@Test
-	@SuppressWarnings("unchecked")
-	public void findConnectionByKey() {
-		insertFacebookConnection();
-		assertFacebookConnection((Connection<TestFacebookApi>) connectionRepository.getConnection(new ConnectionKey("facebook", "9")));
-	}
-	
-	@Test(expected=NoSuchConnectionException.class)
-	public void findConnectionByKeyNoSuchConnection() {
-		connectionRepository.getConnection(new ConnectionKey("facebook", "bogus"));
-	}
-
-	@Test
-	public void findConnectionByApiToUser() {
-		insertFacebookConnection();
-		insertFacebookConnection2();	
-		assertFacebookConnection(connectionRepository.getConnection(TestFacebookApi.class, "9"));
-		assertEquals("10", connectionRepository.getConnection(TestFacebookApi.class, "10").getKey().getProviderUserId());
-	}
-
-	@Test(expected=NoSuchConnectionException.class)
-	public void findConnectionByApiToUserNoSuchConnection() {
-		assertFacebookConnection(connectionRepository.getConnection(TestFacebookApi.class, "9"));
-	}
-	
-	@Test
-	public void findPrimaryConnection() {
-		insertFacebookConnection();
-		assertFacebookConnection(connectionRepository.getPrimaryConnection(TestFacebookApi.class));
-	}
-
-	@Test
-	public void findPrimaryConnectionSelectFromMultipleByRank() {
-		insertFacebookConnection2();
-		insertFacebookConnection();
-		assertFacebookConnection(connectionRepository.getPrimaryConnection(TestFacebookApi.class));
-	}
-
-	@Test(expected=NotConnectedException.class)
-	public void findPrimaryConnectionNotConnected() {
-		connectionRepository.getPrimaryConnection(TestFacebookApi.class);
-	}
-
-	@Test
-	public void removeConnections() {
-		insertFacebookConnection();
-		insertFacebookConnection2();
-		assertTrue(dataAccessor.queryForObject("select exists (select 1 from " + getTablePrefix() + "UserConnection where providerId = 'facebook')", Boolean.class));
-		connectionRepository.removeConnections("facebook");
-		assertFalse(dataAccessor.queryForObject("select exists (select 1 from " + getTablePrefix() + "UserConnection where providerId = 'facebook')", Boolean.class));
-	}
-	
-	@Test
-	public void removeConnectionsToProviderNoOp() {
-		connectionRepository.removeConnections("twitter");
-	}
-
-	@Test
-	public void removeConnection() {
-		insertFacebookConnection();
-		assertTrue(dataAccessor.queryForObject("select exists (select 1 from " + getTablePrefix() + "UserConnection where providerId = 'facebook')", Boolean.class));
-		connectionRepository.removeConnection(new ConnectionKey("facebook", "9"));
-		assertFalse(dataAccessor.queryForObject("select exists (select 1 from " + getTablePrefix() + "UserConnection where providerId = 'facebook')", Boolean.class));		
-	}
-
-	@Test
-	public void removeConnectionNoOp() {
-		connectionRepository.removeConnection(new ConnectionKey("facebook", "1"));
-	}
-
-	@Test
-	public void addConnection() {
-		Connection<TestFacebookApi> connection = connectionFactory.createConnection(new AccessGrant("123456789", null, "987654321", 3600L));
-		connectionRepository.addConnection(connection);
-		Connection<TestFacebookApi> restoredConnection = connectionRepository.getPrimaryConnection(TestFacebookApi.class);
-		assertEquals(connection, restoredConnection);	
-		assertNewConnection(restoredConnection);
-	}
-	
-	@Test(expected=DuplicateConnectionException.class)
-	public void addConnectionDuplicate() {
-		Connection<TestFacebookApi> connection = connectionFactory.createConnection(new AccessGrant("123456789", null, "987654321", 3600L));
-		connectionRepository.addConnection(connection);
-		connectionRepository.addConnection(connection);
-	}
-	
-	@Test
-	public void updateConnectionProfileFields() {
-		connectionFactoryRegistry.addConnectionFactory(new TestTwitterConnectionFactory());		
-		insertTwitterConnection();
-		Connection<TestTwitterApi> twitter = connectionRepository.getPrimaryConnection(TestTwitterApi.class);
-		assertEquals("http://twitter.com/kdonald/picture", twitter.getImageUrl());
-		twitter.sync();
-		assertEquals("http://twitter.com/kdonald/a_new_picture", twitter.getImageUrl());
-		connectionRepository.updateConnection(twitter);
-		Connection<TestTwitterApi> twitter2 = connectionRepository.getPrimaryConnection(TestTwitterApi.class);
-		assertEquals("http://twitter.com/kdonald/a_new_picture", twitter2.getImageUrl());
-	}
-	
-	@Test
-	public void updateConnectionAccessFields() {
-		insertFacebookConnection();
-		Connection<TestFacebookApi> facebook = connectionRepository.getPrimaryConnection(TestFacebookApi.class);
-		assertEquals("234567890", facebook.getApi().getAccessToken());
-		facebook.refresh();
-		connectionRepository.updateConnection(facebook);
-		Connection<TestFacebookApi> facebook2 = connectionRepository.getPrimaryConnection(TestFacebookApi.class);
-		assertEquals("765432109", facebook2.getApi().getAccessToken());
-		ConnectionData data = facebook.createData();
-		assertEquals("654321098", data.getRefreshToken());
-	}
-	
-	@Test
-	public void findPrimaryConnection_afterRemove() {
-		insertFacebookConnection();
-		insertFacebookConnection2();    
-		// 9 is the providerUserId of the first Facebook connection
-		connectionRepository.removeConnection(new ConnectionKey("facebook", "9"));
-		assertEquals(1, connectionRepository.findConnections(TestFacebookApi.class).size());
-		assertNotNull(connectionRepository.findPrimaryConnection(TestFacebookApi.class));
-	}
-
-	// subclassing hooks
-	
-	protected String getTablePrefix() {
-		return "";
-	}
-	
-	protected String getSchemaSql() {
-		return "JdbcUsersConnectionRepository.sql";
-	}
-		
-	private void insertTwitterConnection() {
-		dataAccessor.update("insert into " + getTablePrefix() + "UserConnection (userId, providerId, providerUserId, rank, displayName, profileUrl, imageUrl, accessToken, secret, refreshToken, expireTime) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-				"1", "twitter", "1", 1, "@kdonald", "http://twitter.com/kdonald", "http://twitter.com/kdonald/picture", "123456789", "987654321", null, null);
-	}
-	
-	private void insertFacebookConnection() {
-		dataAccessor.update("insert into " + getTablePrefix() + "UserConnection (userId, providerId, providerUserId, rank, displayName, profileUrl, imageUrl, accessToken, secret, refreshToken, expireTime) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-				"1", "facebook", "9", 1, null, null, null, "234567890", null, "345678901", System.currentTimeMillis() + 3600000);
-	}
-	
-	private void insertFacebookConnection2() {
-		dataAccessor.update("insert into " + getTablePrefix() + "UserConnection (userId, providerId, providerUserId, rank, displayName, profileUrl, imageUrl, accessToken, secret, refreshToken, expireTime) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-				"1", "facebook", "10", 2, null, null, null, "456789012", null, "56789012", System.currentTimeMillis() + 3600000);
-	}
-
-	private void insertFacebookConnection3() {
-		dataAccessor.update("insert into " + getTablePrefix() + "UserConnection (userId, providerId, providerUserId, rank, displayName, profileUrl, imageUrl, accessToken, secret, refreshToken, expireTime) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-				"2", "facebook", "11", 2, null, null, null, "456789012", null, "56789012", System.currentTimeMillis() + 3600000);
-	}
-
-	private void insertFacebookConnectionSameFacebookUser() {
-		dataAccessor.update("insert into " + getTablePrefix() + "UserConnection (userId, providerId, providerUserId, rank, displayName, profileUrl, imageUrl, accessToken, secret, refreshToken, expireTime) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-				"2", "facebook", "9", 1, null, null, null, "234567890", null, "345678901", System.currentTimeMillis() + 3600000);
-	}
-
-	private void assertNewConnection(Connection<TestFacebookApi> connection) {
-		assertEquals("facebook", connection.getKey().getProviderId());
-		assertEquals("9", connection.getKey().getProviderUserId());
-		assertEquals("Keith Donald", connection.getDisplayName());
-		assertEquals("http://facebook.com/keith.donald", connection.getProfileUrl());
-		assertEquals("http://facebook.com/keith.donald/picture", connection.getImageUrl());
-		assertTrue(connection.test());
-		TestFacebookApi api = connection.getApi();
-		assertNotNull(api);
-		assertEquals("123456789", api.getAccessToken());
-		assertEquals("123456789", connection.createData().getAccessToken());
-		assertEquals("987654321", connection.createData().getRefreshToken());
-	}
-
-	private void assertTwitterConnection(Connection<TestTwitterApi> twitter) {
-		assertEquals(new ConnectionKey("twitter", "1"), twitter.getKey());
-		assertEquals("@kdonald", twitter.getDisplayName());
-		assertEquals("http://twitter.com/kdonald", twitter.getProfileUrl());
-		assertEquals("http://twitter.com/kdonald/picture", twitter.getImageUrl());
-		TestTwitterApi twitterApi = twitter.getApi();
-		assertEquals("123456789", twitterApi.getAccessToken());		
-		assertEquals("987654321", twitterApi.getSecret());
-		twitter.sync();
-		assertEquals("http://twitter.com/kdonald/a_new_picture", twitter.getImageUrl());
-	}
-
-	private void assertFacebookConnection(Connection<TestFacebookApi> facebook) {
-		assertEquals(new ConnectionKey("facebook", "9"), facebook.getKey());
-		assertEquals(null, facebook.getDisplayName());
-		assertEquals(null, facebook.getProfileUrl());
-		assertEquals(null, facebook.getImageUrl());
-		TestFacebookApi facebookApi = facebook.getApi();
-		assertEquals("234567890", facebookApi.getAccessToken());
-		facebook.sync();
-		assertEquals("Keith Donald", facebook.getDisplayName());
-		assertEquals("http://facebook.com/keith.donald", facebook.getProfileUrl());
-		assertEquals("http://facebook.com/keith.donald/picture", facebook.getImageUrl());		
-	}
-	
-	// test facebook provider
-	
-	private static class TestFacebookConnectionFactory extends OAuth2ConnectionFactory<TestFacebookApi> {
-
-		public TestFacebookConnectionFactory() {
-			super("facebook", new TestFacebookServiceProvider(), new TestFacebookApiAdapter());
-		}
-		
-	}
-
-	private static class TestFacebookServiceProvider implements OAuth2ServiceProvider<TestFacebookApi> {
-
-		public OAuth2Operations getOAuthOperations() {
-			return new OAuth2Operations() {
-				public String buildAuthorizeUrl(GrantType grantType, OAuth2Parameters params) {
-					return null;
-				}
-				public String buildAuthenticateUrl(GrantType grantType, OAuth2Parameters params) {
-					return null;
-				}
-				public String buildAuthorizeUrl(OAuth2Parameters params) {
-					return null;
-				}
-				public String buildAuthenticateUrl(OAuth2Parameters params) {
-					return null;
-				}
-				public AccessGrant exchangeForAccess(String authorizationGrant, String redirectUri, MultiValueMap<String, String> additionalParameters) {
-					return null;
-				}				
-				public AccessGrant exchangeCredentialsForAccess(String username, String password, MultiValueMap<String, String> additionalParameters) {
-					return null;
-				}
-				public AccessGrant refreshAccess(String refreshToken, MultiValueMap<String, String> additionalParameters) {
-					return new AccessGrant("765432109", "read", "654321098", 3600L);
-				}
-				public AccessGrant refreshAccess(String refreshToken, String scope, MultiValueMap<String, String> additionalParameters) {
-					return new AccessGrant("765432109", "read", "654321098", 3600L);
-				}
-				public AccessGrant authenticateClient() {
-					return null;
-				}
-				public AccessGrant authenticateClient(String scope) {
-					return null;
-				}
-            };
-		}
-
-		public TestFacebookApi getApi(final String accessToken) {
-			return new TestFacebookApi() {
-				public String getAccessToken() {
-					return accessToken;
-				}
-			};
-		}
-		
-	}
-
-	public interface TestFacebookApi {
-		
-		String getAccessToken();
-		
-	}
-	
-	private static class TestFacebookApiAdapter implements ApiAdapter<TestFacebookApi> {
-
-		private String accountId = "9";
-		
-		private String name = "Keith Donald";
-		
-		private String profileUrl = "http://facebook.com/keith.donald";
-		
-		private String profilePictureUrl = "http://facebook.com/keith.donald/picture";
-		
-		public boolean test(TestFacebookApi api) {
-			return true;
-		}
-
-		public void setConnectionValues(TestFacebookApi api, ConnectionValues values) {
-			values.setProviderUserId(accountId);
-			values.setDisplayName(name);
-			values.setProfileUrl(profileUrl);
-			values.setImageUrl(profilePictureUrl);
-		}
-
-		public UserProfile fetchUserProfile(TestFacebookApi api) {
-			return new UserProfileBuilder().setName(name).setEmail("keith@interface21.com").setUsername("Keith.Donald").build();
-		}
-
-		public void updateStatus(TestFacebookApi api, String message) {
-			
-		}
-		
-	}
-	
-	// test twitter provider
-	
-	private static class TestTwitterConnectionFactory extends OAuth1ConnectionFactory<TestTwitterApi> {
-
-		public TestTwitterConnectionFactory() {
-			super("twitter", new TestTwitterServiceProvider(), new TestTwitterApiAdapter());
-		}
-		
-	}
-
-	private static class TestTwitterServiceProvider implements OAuth1ServiceProvider<TestTwitterApi> {
-
-		public OAuth1Operations getOAuthOperations() {
-			return null;
-		}
-
-		public TestTwitterApi getApi(final String accessToken, final String secret) {
-			return new TestTwitterApi() {
-				public String getAccessToken() {
-					return accessToken;
-				}
-				public String getSecret() {
-					return secret;
-				}
-			};
-		}
-		
-	}
-		
-	public interface TestTwitterApi {
-		
-		String getAccessToken();
-		
-		String getSecret();
-		
-	}
-	
-	private static class TestTwitterApiAdapter implements ApiAdapter<TestTwitterApi> {
-
-		private String accountId = "1";
-		
-		private String name = "@kdonald";
-		
-		private String profileUrl = "http://twitter.com/kdonald";
-		
-		private String profilePictureUrl = "http://twitter.com/kdonald/a_new_picture";
-		
-		public boolean test(TestTwitterApi api) {
-			return true;
-		}
-
-		public void setConnectionValues(TestTwitterApi api, ConnectionValues values) {
-			values.setProviderUserId(accountId);
-			values.setDisplayName(name);
-			values.setProfileUrl(profileUrl);
-			values.setImageUrl(profilePictureUrl);
-		}
-
-		public UserProfile fetchUserProfile(TestTwitterApi api) {
-			return new UserProfileBuilder().setName(name).setUsername("kdonald").build();			
-		}
-		
-		public void updateStatus(TestTwitterApi api, String message) {
-		}
-		
-	}
-	
-	private static class MySqlCompatibleH2DatabaseConfigurer implements EmbeddedDatabaseConfigurer {
-		public void shutdown(DataSource dataSource, String databaseName) {
-			try {
-				java.sql.Connection connection = dataSource.getConnection();
-				Statement stmt = connection.createStatement();
-				stmt.execute("SHUTDOWN");
-			}
-			catch (SQLException ex) {
-			}
-		}
-		
-		public void configureConnectionProperties(ConnectionProperties properties, String databaseName) {
-			properties.setDriverClass(Driver.class);
-			properties.setUrl(String.format("jdbc:h2:mem:%s;MODE=MYSQL;DB_CLOSE_DELAY=-1", databaseName));
-			properties.setUsername("sa");
-			properties.setPassword("");
-		}
-	}		
-	
 }

--- a/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepositoryTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepositoryTest.java
@@ -98,7 +98,7 @@ public class JdbcUsersConnectionRepositoryTest extends AbstractUsersConnectionRe
 		if (!getTablePrefix().equals("")) {
 			usersConnectionRepository.setTablePrefix(getTablePrefix());
 		}
-		connectionRepository = usersConnectionRepository.createConnectionRepository("1");
+		connectionRepository = usersConnectionRepository.createConnectionRepository(getUserId1());
 	}
 	
 	@After
@@ -110,7 +110,7 @@ public class JdbcUsersConnectionRepositoryTest extends AbstractUsersConnectionRe
 	
 	protected void insertFooConnection() {
 		dataAccessor.update("insert into " + getTablePrefix() + "UserConnection (userId, providerId, providerUserId, rank, displayName, profileUrl, imageUrl, accessToken, secret, refreshToken, expireTime) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-				"1", "foo", "123", 1, "james", null, null, "234", "123", null, System.currentTimeMillis() + 3600000);
+				getUserId1(), "foo", "123", 1, "james", null, null, "234", "123", null, System.currentTimeMillis() + 3600000);
 	}
 	
 	private void insertConnection(ConnectionData data, String userId, int rank) {
@@ -119,28 +119,38 @@ public class JdbcUsersConnectionRepositoryTest extends AbstractUsersConnectionRe
 	}
 	
 	@Override
+	protected String getUserId1() {
+		return "1";
+	}
+
+	@Override
+	protected String getUserId2() {
+		return "2";
+	}
+
+	@Override
 	protected void insertTwitterConnection() {
-		insertConnection(TWITTER_DATA, "1", 1);
+		insertConnection(TWITTER_DATA, getUserId1(), 1);
 	}
 
 	@Override
 	protected void insertFacebookConnection1() {
-		insertConnection(FACEBOOK_DATA_1, "1", 1);
+		insertConnection(FACEBOOK_DATA_1, getUserId1(), 1);
 	}
 	
 	@Override
 	protected void insertFacebookConnection2() {
-		insertConnection(FACEBOOK_DATA_2, "1", 2);
+		insertConnection(FACEBOOK_DATA_2, getUserId1(), 2);
 	}
 
 	@Override
 	protected void insertFacebookConnection3() {
-		insertConnection(FACEBOOK_DATA_3, "2", 2);
+		insertConnection(FACEBOOK_DATA_3, getUserId2(), 2);
 	}
 
 	@Override
 	protected void insertFacebookConnectionSameFacebookUser() {
-		insertConnection(FACEBOOK_DATA_1, "2", 1);
+		insertConnection(FACEBOOK_DATA_1, getUserId2(), 1);
 	}
 	
 	@Test(expected = IllegalArgumentException.class)

--- a/spring-social-core/src/test/java/org/springframework/social/connect/mem/InMemoryUsersConnectionRepositoryTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/mem/InMemoryUsersConnectionRepositoryTest.java
@@ -15,558 +15,67 @@
  */
 package org.springframework.social.connect.mem;
 
-import static org.junit.Assert.*;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
-import org.springframework.social.connect.ApiAdapter;
 import org.springframework.social.connect.Connection;
 import org.springframework.social.connect.ConnectionData;
-import org.springframework.social.connect.ConnectionKey;
 import org.springframework.social.connect.ConnectionRepository;
-import org.springframework.social.connect.ConnectionSignUp;
-import org.springframework.social.connect.ConnectionValues;
-import org.springframework.social.connect.DuplicateConnectionException;
-import org.springframework.social.connect.NoSuchConnectionException;
-import org.springframework.social.connect.NotConnectedException;
-import org.springframework.social.connect.UserProfile;
-import org.springframework.social.connect.UserProfileBuilder;
-import org.springframework.social.connect.support.ConnectionFactoryRegistry;
-import org.springframework.social.connect.support.OAuth1ConnectionFactory;
-import org.springframework.social.connect.support.OAuth2ConnectionFactory;
-import org.springframework.social.oauth1.OAuth1Operations;
-import org.springframework.social.oauth1.OAuth1ServiceProvider;
-import org.springframework.social.oauth2.AccessGrant;
-import org.springframework.social.oauth2.GrantType;
-import org.springframework.social.oauth2.OAuth2Operations;
-import org.springframework.social.oauth2.OAuth2Parameters;
-import org.springframework.social.oauth2.OAuth2ServiceProvider;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
+import org.springframework.social.connect.UsersConnectionRepository;
+import org.springframework.social.connect.jdbc.AbstractUsersConnectionRepositoryTest;
 
-public class InMemoryUsersConnectionRepositoryTest {
+public class InMemoryUsersConnectionRepositoryTest extends AbstractUsersConnectionRepositoryTest {
 
-	private ConnectionFactoryRegistry connectionFactoryRegistry;
-	
 	private ConnectionRepository connectionRepository;
-
-	private TestFacebookConnectionFactory facebookConnectionFactory;
-
-	private TestTwitterConnectionFactory twitterConnectionFactory;
 
 	private InMemoryUsersConnectionRepository usersConnectionRepository;
 
 	@Before
 	public void setUp() {
-		connectionFactoryRegistry = new ConnectionFactoryRegistry();
-		usersConnectionRepository = new InMemoryUsersConnectionRepository(connectionFactoryRegistry);
+		usersConnectionRepository = new InMemoryUsersConnectionRepository(getConnectionFactoryRegistry());
 		connectionRepository = usersConnectionRepository.createConnectionRepository("1");
-		facebookConnectionFactory = registerFacebookConnectionFactory();
-		twitterConnectionFactory = registerTwitterConnectionFactory();
 	}
 	
-	@After
-	public void tearDown() {
-		connectionFactoryRegistry = null;
-	}
+
 	
-	@Test
-	public void findUserIdWithConnection() {
-		insertFacebookConnection();
-		List<String> userIds = usersConnectionRepository.findUserIdsWithConnection(connectionRepository.getPrimaryConnection(TestFacebookApi.class));
-		assertEquals("1", userIds.get(0));
+	@Override
+	protected ConnectionRepository getConnectionRepository() {
+		return connectionRepository;
 	}
 
-	@Test
-	public void findUserIdWithConnectionNoSuchConnection() {
-		Connection<TestFacebookApi> connection = facebookConnectionFactory.createConnection(new AccessGrant("12345"));
-		assertEquals(0, usersConnectionRepository.findUserIdsWithConnection(connection).size());
+	@Override
+	protected UsersConnectionRepository getUsersConnectionRepository() {
+		return usersConnectionRepository;
 	}
-	
-	@Test
-	public void findUserIdWithConnectionMultipleConnectionsToSameProviderUser() {
-		insertFacebookConnection();
-		insertFacebookConnectionSameFacebookUser();
-		List<String> localUserIds = usersConnectionRepository.findUserIdsWithConnection(connectionRepository.getPrimaryConnection(TestFacebookApi.class));
-		assertEquals(2, localUserIds.size());
-		assertEquals("2", localUserIds.get(0));
-		assertEquals("1", localUserIds.get(1));
-	}
-
-	@Test
-	public void findUserIdWithConnectionNoConnection_withWorkingConnectionSignUp() {		
-		Connection<TestFacebookApi> connection = facebookConnectionFactory.createConnection(new AccessGrant("12345"));
-		usersConnectionRepository.setConnectionSignUp(new ConnectionSignUp() {
-			public String execute(Connection<?> connection) {
-				return "batman";
-			}
-		});
-		List<String> userIds = usersConnectionRepository.findUserIdsWithConnection(connection);
-		assertEquals(1, userIds.size());
-		assertEquals("batman", userIds.get(0));
-	}
-
-	@Test
-	public void findUserIdWithConnectionNoConnection_withConnectionSignUpReturningNull() {		
-		Connection<TestFacebookApi> connection = facebookConnectionFactory.createConnection(new AccessGrant("12345"));
-		usersConnectionRepository.setConnectionSignUp(new ConnectionSignUp() {
-			public String execute(Connection<?> connection) {
-				return null;
-			}
-		});
-		List<String> userIds = usersConnectionRepository.findUserIdsWithConnection(connection);
-		assertEquals(0, userIds.size());
-	}
-	
-	@Test
-	public void findUserIdsConnectedTo() {
-		insertFacebookConnection();
-		insertFacebookConnection3();
-		Set<String> localUserIds = usersConnectionRepository.findUserIdsConnectedTo("facebook", new HashSet<String>(Arrays.asList("12345", "45678")));
-		assertEquals(2, localUserIds.size());
-		assertTrue(localUserIds.contains("1"));
-		assertTrue(localUserIds.contains("2"));		
-	}
-	
-	@Test
-	@SuppressWarnings("unchecked")
-	public void findAllConnections() {
-		insertTwitterConnection();
-		insertFacebookConnection();
-		MultiValueMap<String, Connection<?>> connections = connectionRepository.findAllConnections();
-		assertEquals(2, connections.size());
-		Connection<TestTwitterApi> twitter = (Connection<TestTwitterApi>) connections.getFirst("twitter");
-		assertTwitterConnection(twitter);
-		Connection<TestFacebookApi> facebook = (Connection<TestFacebookApi>) connections.getFirst("facebook");
-		assertFacebookConnection(facebook);
-	}
-
-	@Test
-	public void findAllConnectionsMultipleConnectionResults() {
-		insertTwitterConnection();
-		insertFacebookConnection();
-		insertFacebookConnection2();
-		MultiValueMap<String, Connection<?>> connections = connectionRepository.findAllConnections();
-		assertEquals(1, connections.get("twitter").size());
-		assertEquals(2, connections.size());
-		assertEquals(2, connections.get("facebook").size());
-	}
-	
-	@Test
-	public void findAllConnectionsEmptyResult() {
-		MultiValueMap<String, Connection<?>> connections = connectionRepository.findAllConnections();
-		assertEquals(0, connections.size());
-	}	
-	
-	@Test
-	@SuppressWarnings("unchecked")
-	public void findConnectionsByProviderId() {
-		insertTwitterConnection();
-		List<Connection<?>> connections = connectionRepository.findConnections("twitter");
-		assertEquals(1, connections.size());
-		assertTwitterConnection((Connection<TestTwitterApi>) connections.get(0));
-	}
-
-	@Test
-	public void findConnectionsByProviderIdEmptyResult() {
-		assertTrue(connectionRepository.findConnections("facebook").isEmpty());
-	}
-	
-	@Test
-	public void findConnectionsByApi() {
-		insertFacebookConnection();
-		insertFacebookConnection2();
-		List<Connection<TestFacebookApi>> connections = connectionRepository.findConnections(TestFacebookApi.class);
-		assertEquals(2, connections.size());
-		assertFacebookConnection(connections.get(0));
-	}
-	
-	@Test
-	public void findConnectionsByApiEmptyResult() {
-		assertTrue(connectionRepository.findConnections(TestFacebookApi.class).isEmpty());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void findConnectionsToUsers() {
-		insertTwitterConnection();
-		insertFacebookConnection();
-		insertFacebookConnection2();
-		MultiValueMap<String, String> providerUsers = new LinkedMultiValueMap<String, String>();
-		providerUsers.add("facebook", "9");
-		providerUsers.add("facebook", "12345");
-		providerUsers.add("twitter", "habuma");
-		MultiValueMap<String, Connection<?>> connectionsForUsers = connectionRepository.findConnectionsToUsers(providerUsers);
-		assertEquals(2, connectionsForUsers.size());
-		assertEquals("12345", connectionsForUsers.getFirst("facebook").getKey().getProviderUserId());
-		assertFacebookConnection((Connection<TestFacebookApi>) connectionsForUsers.get("facebook").get(0));
-		assertTwitterConnection((Connection<TestTwitterApi>) connectionsForUsers.getFirst("twitter"));
-	}
-
-	@Test
-	public void findConnectionsToUsersEmptyResult() {
-		MultiValueMap<String, String> providerUsers = new LinkedMultiValueMap<String, String>();
-		providerUsers.add("facebook", "12345");
-		assertTrue(connectionRepository.findConnectionsToUsers(providerUsers).isEmpty());
-	}
-	
-	@Test(expected=IllegalArgumentException.class)
-	public void findConnectionsToUsersEmptyInput() {
-		MultiValueMap<String, String> providerUsers = new LinkedMultiValueMap<String, String>();
-		connectionRepository.findConnectionsToUsers(providerUsers);
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void findConnectionByKey() {
-		insertFacebookConnection();
-		assertFacebookConnection((Connection<TestFacebookApi>) connectionRepository.getConnection(new ConnectionKey("facebook", "12345")));
-	}
-	
-	@Test(expected=NoSuchConnectionException.class)
-	public void findConnectionByKeyNoSuchConnection() {
-		connectionRepository.getConnection(new ConnectionKey("facebook", "bogus"));
-	}
-	
-	@Test
-	public void findConnectionByApiToUser() {
-		insertFacebookConnection();
-		insertFacebookConnection2();	
-		assertFacebookConnection(connectionRepository.getConnection(TestFacebookApi.class, "12345"));
-		assertEquals("54321", connectionRepository.getConnection(TestFacebookApi.class, "54321").getKey().getProviderUserId());
-	}
-
-	@Test(expected=NoSuchConnectionException.class)
-	public void findConnectionByApiToUserNoSuchConnection() {
-		assertFacebookConnection(connectionRepository.getConnection(TestFacebookApi.class, "54321"));
-	}
-	
-	@Test
-	public void findPrimaryConnection() {
-		insertFacebookConnection();
-		assertFacebookConnection(connectionRepository.getPrimaryConnection(TestFacebookApi.class));
-	}
-
-	@Test(expected=NotConnectedException.class)
-	public void findPrimaryConnectionNotConnected() {
-		connectionRepository.getPrimaryConnection(TestFacebookApi.class);
-	}
-
-	@Test
-	public void removeConnections() {
-		insertFacebookConnection();
-		insertFacebookConnection2();
-		assertEquals(2, connectionRepository.findConnections("facebook").size());
-		connectionRepository.removeConnections("facebook");
-		assertEquals(0, connectionRepository.findConnections("facebook").size());
-	}
-
-	@Test
-	public void removeConnectionsToProviderNoOp() {
-		connectionRepository.removeConnections("twitter");
-	}
-	
-	@Test
-	public void removeConnection() {
-		insertFacebookConnection();
-		insertFacebookConnection2();
-		assertEquals(2, connectionRepository.findConnections("facebook").size());
-		connectionRepository.removeConnection(new ConnectionKey("facebook", "12345"));
-		assertEquals(1, connectionRepository.findConnections("facebook").size());
-	}
-
-	@Test
-	public void removeConnectionNoOp() {
-		connectionRepository.removeConnection(new ConnectionKey("facebook", "1"));
-	}
-	
-	@Test
-	public void addConnection() {
-		Connection<TestFacebookApi> connection = facebookConnectionFactory.createConnection(new AccessGrant("123456789", null, "987654321", 3600L));
-		connectionRepository.addConnection(connection);
-		Connection<TestFacebookApi> restoredConnection = connectionRepository.getPrimaryConnection(TestFacebookApi.class);
-		assertEquals(connection, restoredConnection);	
-		assertNewConnection(restoredConnection);
-	}
-
-	@Test(expected=DuplicateConnectionException.class)
-	public void addConnectionDuplicate() {
-		Connection<TestFacebookApi> connection = facebookConnectionFactory.createConnection(new AccessGrant("123456789", null, "987654321", 3600L));
-		connectionRepository.addConnection(connection);
-		connectionRepository.addConnection(connection);
-	}
-
-	@Test
-	public void updateConnectionProfileFields() {
-		insertTwitterConnection();
-		Connection<TestTwitterApi> twitter = connectionRepository.getPrimaryConnection(TestTwitterApi.class);
-		assertEquals("http://twitter.com/habuma/picture", twitter.getImageUrl());
-		twitter.sync();
-		assertEquals("http://twitter.com/habuma/a_new_picture", twitter.getImageUrl());
-		connectionRepository.updateConnection(twitter);
-		Connection<TestTwitterApi> twitter2 = connectionRepository.getPrimaryConnection(TestTwitterApi.class);
-		assertEquals("http://twitter.com/habuma/a_new_picture", twitter2.getImageUrl());
-	}
-	
-	@Test
-	public void updateConnectionAccessFields() {
-		insertFacebookConnection();
-		Connection<TestFacebookApi> facebook = connectionRepository.getPrimaryConnection(TestFacebookApi.class);
-		assertEquals("ACCESS_TOKEN", facebook.getApi().getAccessToken());
-		facebook.refresh();
-		connectionRepository.updateConnection(facebook);
-		Connection<TestFacebookApi> facebook2 = connectionRepository.getPrimaryConnection(TestFacebookApi.class);
-		assertEquals("765432109", facebook2.getApi().getAccessToken());
-		ConnectionData data = facebook.createData();
-		assertEquals("654321098", data.getRefreshToken());
-	}
-
 
 	// PRIVATE SUPPORT METHODS
-
-	private TestFacebookConnectionFactory registerFacebookConnectionFactory() {
-		TestFacebookConnectionFactory facebookConnectionFactory = new TestFacebookConnectionFactory();
-		connectionFactoryRegistry.addConnectionFactory(facebookConnectionFactory);
-		return facebookConnectionFactory;
+	
+	private void insertFacebookConnection(ConnectionData data, String userId) {
+		Connection<TestFacebookApi> facebookConnection = getFacebookConnectionFactory().createConnection(data);
+		usersConnectionRepository.createConnectionRepository(userId).addConnection(facebookConnection);
 	}
-
-	private void insertFacebookConnection() {
-		Connection<TestFacebookApi> facebookConnection = facebookConnectionFactory.createConnection(new ConnectionData("facebook", "12345", "Craig Walls", "http://facebook.com/habuma", "http://facebook.com/habuma/picture", "ACCESS_TOKEN", "SECRET", null, null));		
-		connectionRepository.addConnection(facebookConnection);
-	}
-
-	private void insertFacebookConnection2() {
-		Connection<TestFacebookApi> facebookConnection = facebookConnectionFactory.createConnection(new ConnectionData("facebook", "54321", "Chuck Wagon", "http://facebook.com/cwagon", "http://facebook.com/cwagon/picture", "ACCESS_TOKEN2", "SECRET", null, null));		
-		connectionRepository.addConnection(facebookConnection);
-	}
-
-	private void insertFacebookConnection3() {
-		Connection<TestFacebookApi> facebookConnection = facebookConnectionFactory.createConnection(new ConnectionData("facebook", "45678", "Art Names", "http://facebook.com/art", "http://facebook.com/art/picture", "ACCESS_TOKEN3", "SECRET", null, null));		
-		usersConnectionRepository.createConnectionRepository("2").addConnection(facebookConnection);
-	}
-
-	private void insertFacebookConnectionSameFacebookUser() {
-		Connection<TestFacebookApi> facebookConnection = facebookConnectionFactory.createConnection(new ConnectionData("facebook", "12345", "Craig Walls", "http://facebook.com/habuma", "http://facebook.com/habuma/picture", "ACCESS_TOKEN", "SECRET", null, null));		
-		usersConnectionRepository.createConnectionRepository("2").addConnection(facebookConnection);
-	}
-
-	private void insertTwitterConnection() {
-		Connection<TestTwitterApi> twitterConnection = twitterConnectionFactory.createConnection(new ConnectionData("twitter", "habuma", "@habuma", "http://twitter.com/habuma", "http://twitter.com/habuma/picture", "ACCESS_TOKEN", "SECRET", "REFRESH_TOKEN", null));
+	
+	@Override
+	protected void insertTwitterConnection() {
+		Connection<TestTwitterApi> twitterConnection = getTwitterConnectionFactory().createConnection(TWITTER_DATA);
 		connectionRepository.addConnection(twitterConnection);
 	}
 
-	private TestTwitterConnectionFactory registerTwitterConnectionFactory() {
-		TestTwitterConnectionFactory twitterConnectionFactory = new TestTwitterConnectionFactory();
-		connectionFactoryRegistry.addConnectionFactory(twitterConnectionFactory);
-		return twitterConnectionFactory;
+	@Override
+	protected void insertFacebookConnection1() {
+		insertFacebookConnection(FACEBOOK_DATA_1, "1");
 	}
 
-	
-	private void assertTwitterConnection(Connection<TestTwitterApi> twitter) {
-		assertEquals(new ConnectionKey("twitter", "habuma"), twitter.getKey());
-		assertEquals("@habuma", twitter.getDisplayName());
-		assertEquals("http://twitter.com/habuma", twitter.getProfileUrl());
-		assertEquals("http://twitter.com/habuma/picture", twitter.getImageUrl());
-		TestTwitterApi twitterApi = twitter.getApi();
-		assertEquals("ACCESS_TOKEN", twitterApi.getAccessToken());		
-		assertEquals("SECRET", twitterApi.getSecret());
-		twitter.sync();
-		assertEquals("http://twitter.com/habuma/a_new_picture", twitter.getImageUrl());
-	}
-	
-	private void assertFacebookConnection(Connection<TestFacebookApi> facebook) {
-		assertEquals(new ConnectionKey("facebook", "12345"), facebook.getKey());
-		assertEquals("Craig Walls", facebook.getDisplayName());
-		assertEquals("http://facebook.com/habuma", facebook.getProfileUrl());
-		assertEquals("http://facebook.com/habuma/picture", facebook.getImageUrl());
-		TestFacebookApi facebookApi = facebook.getApi();
-		assertEquals("ACCESS_TOKEN", facebookApi.getAccessToken());
-		facebook.sync();
-		assertEquals("Craig Walls", facebook.getDisplayName());
-		assertEquals("http://facebook.com/habuma", facebook.getProfileUrl());
-		assertEquals("http://facebook.com/habuma/picture", facebook.getImageUrl());		
+	@Override
+	protected void insertFacebookConnection2() {
+		insertFacebookConnection(FACEBOOK_DATA_2, "1");
 	}
 
-	private void assertNewConnection(Connection<TestFacebookApi> connection) {
-		assertEquals("facebook", connection.getKey().getProviderId());
-		assertEquals("12345", connection.getKey().getProviderUserId());
-		assertEquals("Craig Walls", connection.getDisplayName());
-		assertEquals("http://facebook.com/habuma", connection.getProfileUrl());
-		assertEquals("http://facebook.com/habuma/picture", connection.getImageUrl());
-		assertTrue(connection.test());
-		TestFacebookApi api = connection.getApi();
-		assertNotNull(api);
-		assertEquals("123456789", api.getAccessToken());
-		assertEquals("123456789", connection.createData().getAccessToken());
-		assertEquals("987654321", connection.createData().getRefreshToken());
+	@Override
+	protected void insertFacebookConnection3() {
+		insertFacebookConnection(FACEBOOK_DATA_3, "2");
 	}
 
-
-	// test facebook provider
-	
-	private static class TestFacebookConnectionFactory extends OAuth2ConnectionFactory<TestFacebookApi> {
-
-		public TestFacebookConnectionFactory() {
-			super("facebook", new TestFacebookServiceProvider(), new TestFacebookApiAdapter());
-		}
-		
+	@Override
+	protected void insertFacebookConnectionSameFacebookUser() {
+		insertFacebookConnection(FACEBOOK_DATA_1, "2");
 	}
-
-	private static class TestFacebookServiceProvider implements OAuth2ServiceProvider<TestFacebookApi> {
-
-		public OAuth2Operations getOAuthOperations() {
-			return new OAuth2Operations() {
-				public String buildAuthorizeUrl(GrantType grantType, OAuth2Parameters params) {
-					return null;
-				}
-				public String buildAuthenticateUrl(GrantType grantType, OAuth2Parameters params) {
-					return null;
-				}
-				public String buildAuthorizeUrl(OAuth2Parameters params) {
-					return null;
-				}
-				public String buildAuthenticateUrl(OAuth2Parameters params) {
-					return null;
-				}
-				public AccessGrant exchangeForAccess(String authorizationGrant, String redirectUri, MultiValueMap<String, String> additionalParameters) {
-					return null;
-				}				
-				public AccessGrant exchangeCredentialsForAccess(String username, String password, MultiValueMap<String, String> additionalParameters) {
-					return null;
-				}
-				public AccessGrant refreshAccess(String refreshToken, MultiValueMap<String, String> additionalParameters) {
-					return new AccessGrant("765432109", "read", "654321098", 3600L);
-				}
-				public AccessGrant refreshAccess(String refreshToken, String scope, MultiValueMap<String, String> additionalParameters) {
-					return new AccessGrant("765432109", "read", "654321098", 3600L);
-				}
-				public AccessGrant authenticateClient() {
-					return null;
-				}
-				public AccessGrant authenticateClient(String scope) {
-					return null;
-				}
-            };
-		}
-
-		public TestFacebookApi getApi(final String accessToken) {
-			return new TestFacebookApi() {
-				public String getAccessToken() {
-					return accessToken;
-				}
-			};
-		}
-		
-	}
-
-	public interface TestFacebookApi {
-		
-		String getAccessToken();
-		
-	}
-	
-	private static class TestFacebookApiAdapter implements ApiAdapter<TestFacebookApi> {
-
-		private String accountId = "12345";
-		
-		private String name = "Craig Walls";
-		
-		private String profileUrl = "http://facebook.com/habuma";
-		
-		private String profilePictureUrl = "http://facebook.com/habuma/picture";
-		
-		public boolean test(TestFacebookApi api) {
-			return true;
-		}
-
-		public void setConnectionValues(TestFacebookApi api, ConnectionValues values) {
-			values.setProviderUserId(accountId);
-			values.setDisplayName(name);
-			values.setProfileUrl(profileUrl);
-			values.setImageUrl(profilePictureUrl);
-		}
-
-		public UserProfile fetchUserProfile(TestFacebookApi api) {
-			return new UserProfileBuilder().setName(name).setEmail("cwalls@gopivotal.com").setUsername("Craig Walls").build();
-		}
-
-		public void updateStatus(TestFacebookApi api, String message) {
-			
-		}
-		
-	}
-	
-	// test twitter provider
-
-	private static class TestTwitterConnectionFactory extends OAuth1ConnectionFactory<TestTwitterApi> {
-
-		public TestTwitterConnectionFactory() {
-			super("twitter", new TestTwitterServiceProvider(), new TestTwitterApiAdapter());
-		}
-		
-	}
-
-	private static class TestTwitterServiceProvider implements OAuth1ServiceProvider<TestTwitterApi> {
-
-		public OAuth1Operations getOAuthOperations() {
-			return null;
-		}
-
-		public TestTwitterApi getApi(final String accessToken, final String secret) {
-			return new TestTwitterApi() {
-				public String getAccessToken() {
-					return accessToken;
-				}
-				public String getSecret() {
-					return secret;
-				}
-			};
-		}
-		
-	}
-		
-	public interface TestTwitterApi {
-		
-		String getAccessToken();
-		
-		String getSecret();
-		
-	}
-	
-	private static class TestTwitterApiAdapter implements ApiAdapter<TestTwitterApi> {
-
-		private String accountId = "1";
-		
-		private String name = "@habuma";
-		
-		private String profileUrl = "http://twitter.com/habuma";
-		
-		private String profilePictureUrl = "http://twitter.com/habuma/a_new_picture";
-		
-		public boolean test(TestTwitterApi api) {
-			return true;
-		}
-
-		public void setConnectionValues(TestTwitterApi api, ConnectionValues values) {
-			values.setProviderUserId(accountId);
-			values.setDisplayName(name);
-			values.setProfileUrl(profileUrl);
-			values.setImageUrl(profilePictureUrl);
-		}
-
-		public UserProfile fetchUserProfile(TestTwitterApi api) {
-			return new UserProfileBuilder().setName(name).setUsername("habuma").build();			
-		}
-		
-		public void updateStatus(TestTwitterApi api, String message) {
-		}
-		
-	}
-
 }

--- a/spring-social-core/src/test/java/org/springframework/social/connect/mem/InMemoryUsersConnectionRepositoryTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/mem/InMemoryUsersConnectionRepositoryTest.java
@@ -31,7 +31,7 @@ public class InMemoryUsersConnectionRepositoryTest extends AbstractUsersConnecti
 	@Before
 	public void setUp() {
 		usersConnectionRepository = new InMemoryUsersConnectionRepository(getConnectionFactoryRegistry());
-		connectionRepository = usersConnectionRepository.createConnectionRepository("1");
+		connectionRepository = usersConnectionRepository.createConnectionRepository(getUserId1());
 	}
 	
 
@@ -61,21 +61,31 @@ public class InMemoryUsersConnectionRepositoryTest extends AbstractUsersConnecti
 
 	@Override
 	protected void insertFacebookConnection1() {
-		insertFacebookConnection(FACEBOOK_DATA_1, "1");
+		insertFacebookConnection(FACEBOOK_DATA_1, getUserId1());
 	}
 
 	@Override
 	protected void insertFacebookConnection2() {
-		insertFacebookConnection(FACEBOOK_DATA_2, "1");
+		insertFacebookConnection(FACEBOOK_DATA_2, getUserId1());
 	}
 
 	@Override
 	protected void insertFacebookConnection3() {
-		insertFacebookConnection(FACEBOOK_DATA_3, "2");
+		insertFacebookConnection(FACEBOOK_DATA_3, getUserId2());
 	}
 
 	@Override
 	protected void insertFacebookConnectionSameFacebookUser() {
-		insertFacebookConnection(FACEBOOK_DATA_1, "2");
+		insertFacebookConnection(FACEBOOK_DATA_1, getUserId2());
+	}
+
+	@Override
+	protected String getUserId1() {
+		return "1";
+	}
+
+	@Override
+	protected String getUserId2() {
+		return "2";
 	}
 }

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubUsersConnectionRepository.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubUsersConnectionRepository.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import org.springframework.social.connect.Connection;
 import org.springframework.social.connect.ConnectionRepository;
+import org.springframework.social.connect.ConnectionSignUp;
 import org.springframework.social.connect.UsersConnectionRepository;
 
 public class StubUsersConnectionRepository implements UsersConnectionRepository {
@@ -46,6 +47,11 @@ public class StubUsersConnectionRepository implements UsersConnectionRepository 
 
 	public ConnectionRepository createConnectionRepository(String userId) {
 		return new StubConnectionRepository();
+	}
+
+	@Override
+	public void setConnectionSignUp(ConnectionSignUp connectionSignUp) {
+		
 	}
 
 }


### PR DESCRIPTION
- Allows easier testing of own implementations
- Removes code duplication
