### PR TITLE
ProviderSignInAttempt is not Serializable and ProviderSignInUtils does not respect session strategy correctly

### DIFF
--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
@@ -321,7 +321,7 @@ public class SocialAuthenticationFilter extends AbstractAuthenticationProcessing
 	}
 	
 	private void addSignInAttempt(HttpSession session, Connection<?> connection) {
-		session.setAttribute(ProviderSignInAttempt.SESSION_ATTRIBUTE, new ProviderSignInAttempt(connection, authServiceLocator, usersConnectionRepository));
+		session.setAttribute(ProviderSignInAttempt.SESSION_ATTRIBUTE, new ProviderSignInAttempt(connection));
 	}
 
 	private static final String DEFAULT_FAILURE_URL = "/signin";

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInAttempt.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInAttempt.java
@@ -27,7 +27,7 @@ import org.springframework.social.connect.UsersConnectionRepository;
  * Models an attempt to sign-in to the application using a provider user identity.
  * Instances are created when the provider sign-in process could not be completed because no local user is associated with the provider user.
  * This could happen because the user has not yet signed up with the application, or has not yet connected their local application identity with the their provider identity.
- * For the former scenario, callers should invoke {@link #addConnection(String)} post-signup to establish a connection between a new user account and the provider account.
+ * For the former scenario, callers should invoke {@link #addConnection(String,ConnectionFactoryLocator,UsersConnectionRepository)} post-signup to establish a connection between a new user account and the provider account.
  * For the latter, existing users should sign-in using their local application credentials and formally connect to the provider they also wish to authenticate with.
  * @author Keith Donald
  */
@@ -40,15 +40,9 @@ public class ProviderSignInAttempt implements Serializable {
 	public static final String SESSION_ATTRIBUTE = ProviderSignInAttempt.class.getName();
 
 	private final ConnectionData connectionData;
-	
-	private final ConnectionFactoryLocator connectionFactoryLocator;
-	
-	private final UsersConnectionRepository connectionRepository;
 		
-	public ProviderSignInAttempt(Connection<?> connection, ConnectionFactoryLocator connectionFactoryLocator, UsersConnectionRepository connectionRepository) {
-		this.connectionData = connection.createData();
-		this.connectionFactoryLocator = connectionFactoryLocator;
-		this.connectionRepository = connectionRepository;		
+	public ProviderSignInAttempt(Connection<?> connection) {
+		this.connectionData = connection.createData();	
 	}
 	
 	/**
@@ -56,7 +50,7 @@ public class ProviderSignInAttempt implements Serializable {
 	 * Using this connection you may fetch a {@link Connection#fetchUserProfile() provider user profile} and use that to pre-populate a local user registration/signup form.
 	 * You can also lookup the id of the provider and use that to display a provider-specific user-sign-in-attempt flash message e.g. "Your Facebook Account is not connected to a Local account. Please sign up."
 	 */
-	public Connection<?> getConnection() {
+	public Connection<?> getConnection(ConnectionFactoryLocator connectionFactoryLocator) {
 		return connectionFactoryLocator.getConnectionFactory(connectionData.getProviderId()).createConnection(connectionData);
 	}
 	
@@ -64,8 +58,8 @@ public class ProviderSignInAttempt implements Serializable {
 	 * Connect the new local user to the provider.
 	 * @throws DuplicateConnectionException if the user already has this connection
 	 */
-	void addConnection(String userId) {
-		connectionRepository.createConnectionRepository(userId).addConnection(getConnection());
+	void addConnection(String userId, ConnectionFactoryLocator connectionFactoryLocator, UsersConnectionRepository connectionRepository) {
+		connectionRepository.createConnectionRepository(userId).addConnection(getConnection(connectionFactoryLocator));
 	}
 
 }

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInController.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInController.java
@@ -259,7 +259,7 @@ public class ProviderSignInController implements InitializingBean {
 	private RedirectView handleSignIn(Connection<?> connection, ConnectionFactory<?> connectionFactory, NativeWebRequest request) {
 		List<String> userIds = usersConnectionRepository.findUserIdsWithConnection(connection);
 		if (userIds.size() == 0) {
-			ProviderSignInAttempt signInAttempt = new ProviderSignInAttempt(connection, connectionFactoryLocator, usersConnectionRepository);
+			ProviderSignInAttempt signInAttempt = new ProviderSignInAttempt(connection);
 			sessionStrategy.setAttribute(request, ProviderSignInAttempt.SESSION_ATTRIBUTE, signInAttempt);
 			return redirect(signUpUrl);
 		} else if (userIds.size() == 1) {

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInUtils.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInUtils.java
@@ -16,6 +16,8 @@
 package org.springframework.social.connect.web;
 
 import org.springframework.social.connect.Connection;
+import org.springframework.social.connect.ConnectionFactoryLocator;
+import org.springframework.social.connect.UsersConnectionRepository;
 import org.springframework.web.context.request.RequestAttributes;
 
 /**
@@ -25,28 +27,20 @@ import org.springframework.web.context.request.RequestAttributes;
 public class ProviderSignInUtils {
 
 	private SessionStrategy sessionStrategy;
+	private ConnectionFactoryLocator connectionFactoryLocator;
+	private UsersConnectionRepository connectionRepository;
 
-	public ProviderSignInUtils() {
-		this(new HttpSessionSessionStrategy());
+
+	public ProviderSignInUtils( ConnectionFactoryLocator connectionFactoryLocator,UsersConnectionRepository connectionRepository) {
+		this(new HttpSessionSessionStrategy(),connectionFactoryLocator,connectionRepository);
 	}
 	
-	public ProviderSignInUtils(SessionStrategy sessionStrategy) {
+	public ProviderSignInUtils(SessionStrategy sessionStrategy,ConnectionFactoryLocator connectionFactoryLocator,UsersConnectionRepository connectionRepository) {
 		this.sessionStrategy = sessionStrategy;
+		this.connectionFactoryLocator = connectionFactoryLocator;
+		this.connectionRepository = connectionRepository;
 	}
-	
-	/**
-	 * Get the connection to the provider user the client attempted to sign-in as.
-	 * Using this connection you may fetch a {@link Connection#fetchUserProfile() provider user profile} and use that to pre-populate a local user registration/signup form.
-	 * You can also lookup the id of the provider and use that to display a provider-specific user-sign-in-attempt flash message e.g. "Your Facebook Account is not connected to a Local account. Please sign up."
-	 * Must be called before handlePostSignUp() or else the sign-in attempt will have been cleared from the session.
-	 * Returns null if no provider sign-in has been attempted for the current user session.
-	 * @param request the current request attributes, used to extract sign-in attempt information from the current user session
-	 * @deprecated User instance method {@link #getConnectionFromSession(RequestAttributes)} instead.
-	 */
-	public static Connection<?> getConnection(RequestAttributes request) {
-		ProviderSignInAttempt signInAttempt = getProviderUserSignInAttempt(request);
-		return signInAttempt != null ? signInAttempt.getConnection() : null;
-	}
+
 
 	/**
 	 * Get the connection to the provider user the client attempted to sign-in as.
@@ -58,25 +52,10 @@ public class ProviderSignInUtils {
 	 */
 	public Connection<?> getConnectionFromSession(RequestAttributes request) {
 		ProviderSignInAttempt signInAttempt = getProviderUserSignInAttempt(request);
-		return signInAttempt != null ? signInAttempt.getConnection() : null;
+		return signInAttempt != null ? signInAttempt.getConnection(connectionFactoryLocator) : null;
 	}
 
-	/**
-	 * Add the connection to the provider user the client attempted to sign-in with to the new local user's set of connections.
-	 * Should be called after signing-up a new user in the context of a provider sign-in attempt.
-	 * In this context, the user did not yet have a local account but attempted to sign-in using one of his or her existing provider accounts.
-	 * Ensures provider sign-in attempt session context is cleaned up.
-	 * Does nothing if no provider sign-in was attempted for the current user session (is safe to call in that case).
-	 * @param request the current request attributes, used to extract sign-in attempt information from the current user session
-	 * @deprecated Use instance method {@link #doPostSignUp(String, RequestAttributes)} instead.
-	 */
-	public static void handlePostSignUp(String userId, RequestAttributes request) {
-		ProviderSignInAttempt signInAttempt = getProviderUserSignInAttempt(request);
-		if (signInAttempt != null) {
-			signInAttempt.addConnection(userId);
-			request.removeAttribute(ProviderSignInAttempt.SESSION_ATTRIBUTE, RequestAttributes.SCOPE_SESSION);
-		}		
-	}
+
 	
 	/**
 	 * Add the connection to the provider user the client attempted to sign-in with to the new local user's set of connections.
@@ -89,15 +68,15 @@ public class ProviderSignInUtils {
 	public void doPostSignUp(String userId, RequestAttributes request) {
 		ProviderSignInAttempt signInAttempt = getProviderUserSignInAttempt(request);
 		if (signInAttempt != null) {
-			signInAttempt.addConnection(userId);
-			request.removeAttribute(ProviderSignInAttempt.SESSION_ATTRIBUTE, RequestAttributes.SCOPE_SESSION);
+			signInAttempt.addConnection(userId,connectionFactoryLocator,connectionRepository);
+			sessionStrategy.removeAttribute(request,ProviderSignInAttempt.SESSION_ATTRIBUTE);
 		}		
 	}
 
 	// internal helpers
 	
-	private static ProviderSignInAttempt getProviderUserSignInAttempt(RequestAttributes request) {
-		return (ProviderSignInAttempt) request.getAttribute(ProviderSignInAttempt.SESSION_ATTRIBUTE, RequestAttributes.SCOPE_SESSION);
+	private ProviderSignInAttempt getProviderUserSignInAttempt(RequestAttributes request) {
+		return (ProviderSignInAttempt)sessionStrategy.getAttribute(request, ProviderSignInAttempt.SESSION_ATTRIBUTE);
 	}
 	
 }


### PR DESCRIPTION
Modified ProviderSignInAttempt to ensure it is Serializable, and fixed ProviderSignInUtils so it correctly respects an injected SessionStrategy when retrieving ProviderSignInAttempt.  Removed deprecated static methods which are incompatible with SessionStrategy work.