### PR TITLE
All trust selector

### DIFF
--- a/spring-social-core/src/main/java/org/springframework/social/support/ClientHttpRequestFactorySelector.java
+++ b/spring-social-core/src/main/java/org/springframework/social/support/ClientHttpRequestFactorySelector.java
@@ -140,11 +140,11 @@ public class ClientHttpRequestFactorySelector {
 			}
 			return null;
 		}
-
-		public static void setAllTrust(boolean isAllTrust) {
-			HttpComponentsClientRequestFactoryCreator.isAllTrust = isAllTrust;
-		}
 		
+	}
+
+	public static void setAllTrust(boolean isAllTrust) {
+		HttpComponentsClientRequestFactoryCreator.isAllTrust = isAllTrust;
 	}
 
 }


### PR DESCRIPTION
When you work in test environment and should handle SSL handshaking, you could setting AllTrustClient to HttpClient by setting isAllTrust=true
You can find this issue from http://stackoverflow.com/questions/6659360/how-to-solve-javax-net-ssl-sslhandshakeexception-error
If this setter is not accepted, I should override FacebookConnectionFactory-> FacebookServiceProvider->FacebookOAuth2Template->ClientHttpRequestFactorySelector and all kinds of provider's factory without any benefit of exist class function.
