### PR TITLE
Add extension point to decorate RestTemplate or other parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ exploration
 *.iml
 *.ipr
 *.iws
+.idea

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ configure(allprojects) {
         testCompile("junit:junit-dep:${junitVersion}")
         testCompile("org.hamcrest:hamcrest-library:${hamcrestVersion}")
         testCompile("org.mockito:mockito-core:${mockitoVersion}")
+        testCompile("org.springframework:spring-aop:${springVersion}")
+        testCompile("org.aspectj:aspectjrt:${aspectjVersion}")
+        testCompile("org.aspectj:aspectjweaver:${aspectjVersion}")
     }
 
     ext.javadocLinks = [

--- a/docs/manual/src/asciidoc/index.adoc
+++ b/docs/manual/src/asciidoc/index.adoc
@@ -1,5 +1,5 @@
 = Spring Social Reference
-Craig Walls; Keith Donald; Roy Clarkson
+Craig Walls; Keith Donald; Roy Clarkson; Greg Turnquist
 
 The Spring Social project enables your applications to establish
 Connections with Software-as-a-Service (SaaS) Providers such as Facebook
@@ -2524,4 +2524,62 @@ public class TwitterConnectionFactory extends OAuth1ConnectionFactory<Facebook> 
 Consult the source and JavaDoc API for ConnectionFactory and its
 subclasses more information, examples, and advanced customization
 options.
+
+[[section_creatingAProviderProject]]
+=== Extending an existing Service Provider
+
+Are you already using an existing provider like Spring Social GitHub? You may run into the situation where the Spring Social API doesn't cover every operation you need. Or you may wish to apply extra behavior like caching certain operations. This section explores extension points Spring Social's core includes.
+
+[[]]
+==== Adding extra operations
+
+If you look at the implementation you are using, it probably has a core template, like GitHubTemplate. But what if it doesn't have the operation you are looking for? You can either wait for the team to develop it, or write it yourself.
+
+To write your own extension, simply extend the core class and add your own implementation:
+
+[source,java]
+----
+public class ExtendedGitHubTemplate extends GitHubTemplate {
+
+    public static final String API_URL_BASE = "https://api.github.com";
+
+    public ExtendedGitHubTemplate(String githubToken) {
+        super(githubToken);
+    }
+
+    public List<GitHubRepo> findAllRepositories(String type, String name) {
+        return asList(this.getRestTemplate().getForObject(
+                API_URL_BASE + "/{type}/{name}/repos?per_page=100",
+                GitHubRepo[].class, type, name));
+    }
+----
+
+This fragment extends Spring Social GitHub's `GitHubTemplate`. It adds a new method, `findAllRepositories`. By extending the core template, you are granted access to an already-connected `RestTemplate` via `getRestTemplate()`. You have to assemble the URI yourself, but online documentation from the provider puts the power in your hands.
+
+[[]]
+==== Augmenting Spring Social's RestTemplate
+
+By design, Spring Social uses an embedded `RestTemplate` to do the legwork of interacting with the provider. That way, if you are using more than one Spring Social project, each one's individual instance won't collide with other. As a side effect, it may seem hard to apply something like caching. It's not.
+
+Spring Social's `AbstractOAuth2ApiBinding`, the root of all OAuth2-based provider templates, provides a hook ot post process the `RestTemplate` when it gets created.
+
+[source,java]
+----
+public class ExtendedGitHubTemplate extends GitHubTemplate {
+
+    ...
+
+    @Override
+    protected RestTemplate postProcess(RestTemplate restTemplate) {
+        AspectJProxyFactory factory = new AspectJProxyFactory(restTemplate);
+        factory.addAspect(RestTemplateAspect.class);
+        factory.setProxyTargetClass(true);
+        return factory.getProxy()
+    }
+----
+
+In this example, the code extends `GitHubTemplate` and then overrides sthe `postProcess()` method. In Spring Social core, the *restTemplate* is simply passed through during creation and nothing is changed. In this example, the code creates an AspectJ proxy, adds some `RestTemplateAspect` advice, sets the factory to proxy the class and not its interface, and then returns back a proxy.
+
+You can already do things like wrap `GitHubTemplate` operations with caching. This hook enables you to apply any type of advice directly to the `RestTemplate`.
+
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 version                 = 1.1.1.BUILD-SNAPSHOT
+aspectjVersion          = 1.8.5
 h2Version               = 1.3.175
 hamcrestVersion         = 1.3
 httpComponentsVersion   = 4.3.1

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/AbstractOAuth2ApiBinding.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/AbstractOAuth2ApiBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
@@ -37,12 +38,13 @@ import org.springframework.web.client.RestTemplate;
 /**
  * Base class for OAuth 2-based provider API bindings.
  * @author Craig Walls
+ * @author Greg Turnquist
  */
-public abstract class AbstractOAuth2ApiBinding implements ApiBinding {
+public abstract class AbstractOAuth2ApiBinding implements ApiBinding, InitializingBean {
 
 	private final String accessToken;
 
-	private final RestTemplate restTemplate;
+	private RestTemplate restTemplate;
 
 	/**
 	 * Constructs the API template without user authorization. This is useful for accessing operations on a provider's API that do not require user authorization.
@@ -199,5 +201,36 @@ public abstract class AbstractOAuth2ApiBinding implements ApiBinding {
 		client.setRequestFactory(ClientHttpRequestFactorySelector.getRequestFactory());
 		return client;
 	}
+
+	/**
+	 * After construction, include option to decorate the {@link RestTemplate} followed by an optional
+	 * configuration step. Many providers initialize sub-APIs, and this provides a convenient hook.
+	 * @throws Exception
+	 */
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		this.restTemplate = postProcess(this.restTemplate);
+		postConstructionConfiguration();
+	}
+
+	/**
+	 * Extensible hook to decorate {@link RestTemplate} or wrap it with a proxy of any type. By default, it just passes it through with no changes.
+	 *
+	 * @param restTemplate
+	 * @return
+	 */
+	protected RestTemplate postProcess(RestTemplate restTemplate) {
+		return restTemplate;
+	}
+
+	/**
+	 * An extension point to perform key initialization after everything is configured. Existing providers
+	 * are encouraged to migrate any form of constructor-based initialization into this method.
+	 *
+	 * NOTE: To not break backwards compatibility, this method defaults to doing nothing.
+	 */
+	protected void postConstructionConfiguration() {
+	}
+
 
 }

--- a/spring-social-core/src/test/java/org/springframework/social/oauth2/AbstractOAuth2ApiBindingTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/oauth2/AbstractOAuth2ApiBindingTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.oauth2;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.junit.Test;
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
+import org.springframework.util.ClassUtils;
+import org.springframework.web.client.RestTemplate;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test methods for {@link AbstractOAuth2ApiBinding}, to verify the extension point where it's embedded
+ * {@link RestTemplate} can be manipulated, such as wrapping it inside a AOP proxy.
+ *
+ * @author Greg Turnquist
+ */
+public class AbstractOAuth2ApiBindingTest {
+
+	@Test
+	public void testOriginalSocialTemplateToProveBackwardsCompatibility() throws Exception {
+		MySocialTemplate template = new MySocialTemplate("some acces code");
+		template.afterPropertiesSet();
+		RestTemplate restTemplate = template.getRestTemplate();
+
+		assertThat(ClassUtils.isCglibProxy(restTemplate), is(false));
+		assertThat(template.getState(), equalTo("no state here"));
+		assertThat(ClassUtils.isCglibProxy(template.getSubSocialTemplate().getRestTemplate()), is(false));
+	}
+
+	@Test
+	public void testAugmentedSocialTemplate() throws Exception {
+		AugmentedSocialTemplate template = new AugmentedSocialTemplate("some access code", "key piece of data");
+		template.afterPropertiesSet();
+		RestTemplate restTemplate = template.getRestTemplate();
+		restTemplate.getMessageConverters();
+
+		assertThat(ClassUtils.isCglibProxy(restTemplate), is(true));
+		assertThat(template.getState(), equalTo("This template was touched by an aspect"));
+		assertThat(ClassUtils.isCglibProxy(template.getSubSocialTemplate().getRestTemplate()), is(true));
+	}
+
+	/**
+	 * Imaginary social service that extends the {@link AbstractOAuth2ApiBinding}. Used to
+	 * demonstrate default behavior of pass through on {@link RestTemplate}.
+	 * NOTE: This version is patterned like many Spring Social providers that "initSubApis()"
+	 * in the constructor call. Test up above show that backwards compatibility is NOT broken.
+	 */
+	private static class MySocialTemplate extends AbstractOAuth2ApiBinding {
+
+		private String state = "no state here";
+		private MySubSocialTemplate subSocialTemplate;
+
+		public MySocialTemplate(String accessToken) {
+			super(accessToken);
+			initSubApis();
+		}
+
+		private void initSubApis() {
+			this.subSocialTemplate = new MySubSocialTemplate(getRestTemplate());
+		}
+
+		public String getState() {
+			return state;
+		}
+
+		public void setState(String state) {
+			this.state = state;
+		}
+
+		public MySubSocialTemplate getSubSocialTemplate() {
+			return subSocialTemplate;
+		}
+
+	}
+
+	/**
+	 * Imaginary social service that extends the {@link AbstractOAuth2ApiBinding}. Used to
+	 * demonstrate default behavior of pass through on {@link RestTemplate}.
+	 * NOTE: This version moves initSubApis() into the new configuration hook to make it more
+	 * extensible.
+	 */
+	private static class MyRefactoredSocialTemplate extends AbstractOAuth2ApiBinding {
+
+		private String state = "no state here";
+		private MySubSocialTemplate subSocialTemplate;
+
+		public MyRefactoredSocialTemplate(String accessToken) {
+			super(accessToken);
+		}
+
+		private void initSubApis() {
+			this.subSocialTemplate = new MySubSocialTemplate(getRestTemplate());
+		}
+
+		public String getState() {
+			return state;
+		}
+
+		public void setState(String state) {
+			this.state = state;
+		}
+
+		public MySubSocialTemplate getSubSocialTemplate() {
+			return subSocialTemplate;
+		}
+
+		@Override
+		protected void postConstructionConfiguration() {
+			initSubApis();
+		}
+	}
+	/**
+	 * Sample class that represent a subset of operations as commonly seen in Spring Social providers.
+	 */
+	private static class MySubSocialTemplate {
+
+		private final RestTemplate restTemplate;
+
+		public MySubSocialTemplate(RestTemplate restTemplate) {
+			this.restTemplate = restTemplate;
+		}
+
+		public RestTemplate getRestTemplate() {
+			return restTemplate;
+		}
+	}
+
+	/**
+	 * Extension of the imaginary soclail service. Uses Spring Social's extension point to wrap the embedded
+	 * {@link RestTemplate} with some advice.
+	 */
+	private static class AugmentedSocialTemplate extends MyRefactoredSocialTemplate {
+
+		private final String keyPieceOfDataForAugmentation;
+
+		public AugmentedSocialTemplate(String accessToken, String keyPieceOfDataForAugmentation) {
+			super(accessToken);
+			this.keyPieceOfDataForAugmentation = keyPieceOfDataForAugmentation;
+		}
+
+		@Override
+		protected RestTemplate postProcess(RestTemplate restTemplate) {
+			AspectJProxyFactory factory = new AspectJProxyFactory(restTemplate);
+			factory.addAspect(new RestTemplateAdvice(this, this.keyPieceOfDataForAugmentation));
+			factory.setProxyTargetClass(true);
+			return factory.getProxy();
+		}
+
+	}
+
+	/**
+	 * Some Spring AOP advice used to prove ability to wrap embedded {@link }
+	 */
+	@Aspect
+	public static class RestTemplateAdvice {
+
+		private final MyRefactoredSocialTemplate template;
+		private final String keyPieceOfDataForAugmentation;
+
+		public RestTemplateAdvice(MyRefactoredSocialTemplate template, String keyPieceOfDataForAugmentation) {
+			this.template = template;
+			this.keyPieceOfDataForAugmentation = keyPieceOfDataForAugmentation;
+		}
+
+		@Around("execution(* org.springframework.web.client.RestTemplate.*(..))")
+		public Object around(ProceedingJoinPoint point) throws Throwable {
+			template.setState("This template was touched by an aspect");
+			assertThat(this.keyPieceOfDataForAugmentation, is(notNullValue()));
+			return point.proceed();
+		}
+	}
+
+}


### PR DESCRIPTION
* Create a more extensible endpoint instead of initSubApis() found in many providers
* Add documentation to better explain how to extend and augment existing Template solutions
* Craft test cases providing backwards compatibility and show new extensibility