### PR TITLE
Use the latest version of the Spring IO Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         classpath("me.champeau.gradle:gradle-javadoc-hotfix-plugin:0.1")
         classpath('org.asciidoctor:asciidoctor-gradle-plugin:0.7.0')
         classpath('org.asciidoctor:asciidoctor-java-integration:0.1.4.preview.1')
-        classpath('org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE')
+        classpath('io.spring.gradle:spring-io-plugin:0.0.4.RELEASE')
     }
 }
 
@@ -97,8 +97,12 @@ configure(subprojects) { subproject ->
             maven { url "https://repo.spring.io/libs-snapshot" }
         }
 
-        dependencies {
-            springIoVersions "io.spring.platform:platform-versions:${platformVersion}@properties"
+        dependencyManagement {
+            springIoTestRuntime {
+                imports {
+                    mavenBom "io.spring.platform:platform-bom:${platformVersion}"
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This change is necessary to allow Spring IO Platform 2.0 to remove the platform-versions properties file that was deprecated in 1.1. To allow Spring Social's Platform compliance to be verified as part of Spring IO Platform 2.0's build and release process, I'd like this to be included in Spring Social 1.1.x which is the version that's currently in Spring IO Platform 2.0. If you have any questions, please let me know.