### PR TITLE
Proxy User Authentication based on http.proxyUser

### DIFF
--- a/spring-social-core/src/main/java/org/springframework/social/support/ClientHttpRequestFactorySelector.java
+++ b/spring-social-core/src/main/java/org/springframework/social/support/ClientHttpRequestFactorySelector.java
@@ -29,10 +29,14 @@ import java.util.Properties;
 import javax.net.ssl.SSLContext;
 
 import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLContexts;
 import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.protocol.HttpContext;
@@ -42,6 +46,7 @@ import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
 
 
 /**
@@ -100,6 +105,8 @@ public class ClientHttpRequestFactorySelector {
 			if (proxyHost != null) {
 				HttpHost proxy = new HttpHost(proxyHost, proxyPort);
 				CloseableHttpClient httpClient = isAllTrust ? getAllTrustClient(proxy) : getClient(proxy);
+				
+				
 				requestFactory.setHttpClient(httpClient);
 			}
 			
@@ -110,12 +117,14 @@ public class ClientHttpRequestFactorySelector {
 		private static CloseableHttpClient getClient(HttpHost proxy) {
 			return HttpClients.custom()
 					.setProxy(proxy)
+					.setDefaultCredentialsProvider(getProxyCredentials(proxy))
 					.build();
 		}
 
 		private static CloseableHttpClient getAllTrustClient(HttpHost proxy) {
 			return HttpClients.custom()
 					.setProxy(proxy)
+					.setDefaultCredentialsProvider(getProxyCredentials(proxy))
 					.setSslcontext(getSSLContext())
 					.setHostnameVerifier(SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER)
 					.build();
@@ -141,6 +150,23 @@ public class ClientHttpRequestFactorySelector {
 			return null;
 		}
 		
+		private static CredentialsProvider getProxyCredentials(HttpHost proxy) {
+		    Properties properties = System.getProperties();
+		    String proxyUser = properties.getProperty("http.proxyUser");
+		    String proxyPassword = properties.getProperty("http.proxyPassword");
+		    
+		    if(!StringUtils.isEmpty(proxyUser)) {
+			CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+			credentialsProvider.setCredentials(
+				new AuthScope(proxy), 
+				new UsernamePasswordCredentials(proxyUser, proxyPassword));
+			
+			return credentialsProvider;
+		    }
+		    
+		    return null;
+		}
+		
 	}
 
 	/**
@@ -151,5 +177,7 @@ public class ClientHttpRequestFactorySelector {
 	public static void setAllTrust(boolean isAllTrust) {
 		HttpComponentsClientRequestFactoryCreator.isAllTrust = isAllTrust;
 	}
+	
 
 }
+ 


### PR DESCRIPTION
Working behind a proxy that requires user authentication was causing connection error (407) between  local and the service server requests.

When the `http.proxyUser` system property is available and using Apache HttpClient, just add the user credentials (`http.proxyUser` and `http.proxyPassword`) to the `proxy` scope.

Implementation based on Apache HttpClient [official documentation](https://hc.apache.org/httpcomponents-client-ga/examples.html) that worked on my environment. The Unit Tests were ignored, so I leave it as is.

Windows Servers requires NTLM Authentication and the API doesn't support it. Despite the WARN message bellow, the connection was completed successfully.

`WARN  org.apache.http.impl.auth.HttpAuthenticator- NTLM authentication error: Credentials cannot be used for NTLM authentication: org.apache.http.auth.UsernamePasswordCredentials`

Reference: http://stackoverflow.com/questions/6962047/apache-httpclient-4-1-proxy-authentication