### PR TITLE
Add support for app provided 'state' parameter

### DIFF
--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
@@ -180,13 +180,17 @@ public class SocialAuthenticationFilter extends AbstractAuthenticationProcessing
 
 	/**
 	 * Detects a callback request after a user rejects authorization to prevent a never-ending redirect loop.
-	 * Default implementation detects a rejection as a request that has one or more parameters, but none of the expected parameters (oauth_token, code, scope).
+	 * Default implementation detects a rejection as a request that has one or more parameters
+	 * (except 'state' parameter which can be used by application), but none of the expected parameters (oauth_token, code, scope).
 	 * May be overridden to customize rejection detection.
 	 * @param request the request to check for rejection.
 	 * @return true if the request appears to be the result of a rejected authorization; false otherwise.
 	 */
 	protected boolean detectRejection(HttpServletRequest request) {
 		Set<?> parameterKeys = request.getParameterMap().keySet();
+		if ((parameterKeys.size() == 1) && (parameterKeys.contains("state"))) {
+		    return false;
+		}
 		return parameterKeys.size() > 0 
 				&& !parameterKeys.contains("oauth_token") 
 				&& !parameterKeys.contains("code") 

--- a/spring-social-security/src/main/java/org/springframework/social/security/provider/OAuth2AuthenticationService.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/provider/OAuth2AuthenticationService.java
@@ -89,7 +89,7 @@ public class OAuth2AuthenticationService<S> extends AbstractSocialAuthentication
 			OAuth2Parameters params =  new OAuth2Parameters();
 			params.setRedirectUri(buildReturnToUrl(request));
 			setScope(request, params);
-			params.add("state", connectionFactory.generateState()); // TODO: Verify the state value after callback
+			params.add("state", generateState(connectionFactory, request));
 			addCustomParameters(params);
 			throw new SocialAuthenticationRedirectException(getConnectionFactory().getOAuthOperations().buildAuthenticateUrl(params));
 		} else if (StringUtils.hasText(code)) {
@@ -106,6 +106,11 @@ public class OAuth2AuthenticationService<S> extends AbstractSocialAuthentication
 		} else {
 			return null;
 		}
+	}
+
+	private String generateState(OAuth2ConnectionFactory<?> connectionFactory, HttpServletRequest request) {
+	    final String state = request.getParameter("state");
+	    return (state != null) ? state : connectionFactory.generateState();
 	}
 
 	protected String buildReturnToUrl(HttpServletRequest request) {


### PR DESCRIPTION
Hello,
My app needs control over 'state' oauth2 parameter to save/restore app state before/after authentication with social IDPs.
There is over-ridable generateState() method but without any param.
So added some straightforward changes to support getting state http request param from app and sending it back.
I really need this feature and will be appreciate including it in mainstream (or suggesting me if there is some other way w/o fixing the mainstream code to achieve my aims).
Thank you!