### PR TITLE
support SocialAuthenticationFailureHandler in setPostFailureUrl(..)

### DIFF
--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFailureHandler.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFailureHandler.java
@@ -43,4 +43,8 @@ public class SocialAuthenticationFailureHandler implements AuthenticationFailure
 		delegate.onAuthenticationFailure(request, response, failed);
 	}
 
+	public AuthenticationFailureHandler getDelegate() {
+		return delegate;
+	}
+
 }

--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
@@ -21,7 +21,6 @@ import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationServiceException;

--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
@@ -129,7 +129,7 @@ public class SocialAuthenticationFilter extends AbstractAuthenticationProcessing
 
 	/**
 	 * The URL to redirect to if authentication fails or if authorization is denied by the user.
-	 * @param defaultFailureUrl The failure URL. Defaults to "/signin" (relative to the servlet context).
+	 * @param postFailureUrl The failure URL. Defaults to "/signin" (relative to the servlet context).
 	 */
 	public void setPostFailureUrl(String postFailureUrl) {
 		AuthenticationFailureHandler failureHandler = getFailureHandler();

--- a/spring-social-security/src/main/java/org/springframework/social/security/SpringSocialConfigurer.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SpringSocialConfigurer.java
@@ -53,8 +53,6 @@ public class SpringSocialConfigurer extends SecurityConfigurerAdapter<DefaultSec
 
 	private String connectionAddedRedirectUrl;
 
-	private String defaultFailureUrl;
-
 	private boolean alwaysUsePostLoginUrl = false;
 
 	/**
@@ -98,10 +96,6 @@ public class SpringSocialConfigurer extends SecurityConfigurerAdapter<DefaultSec
 
 		if (connectionAddedRedirectUrl != null) {
 			filter.setConnectionAddedRedirectUrl(connectionAddedRedirectUrl);
-		}
-
-		if (defaultFailureUrl != null) {
-			filter.setDefaultFailureUrl(defaultFailureUrl);
 		}
 		
 		http.authenticationProvider(
@@ -149,9 +143,9 @@ public class SpringSocialConfigurer extends SecurityConfigurerAdapter<DefaultSec
 	}
 	
 	/**
-	 * Sets the URL to land on after a failed login.
-	 * @param postFailureUrl the URL to redirect to after a failed login
-     * @return this SpringSocialConfigurer for chained configuration
+	 * Sets the URL to redirect to if authentication fails or if authorization is denied by the user.
+	 * @param postFailureUrl the URL to redirect to after an authentication fail or authorization deny
+	 * @return this SpringSocialConfigurer for chained configuration
 	 */
 	public SpringSocialConfigurer postFailureUrl(String postFailureUrl) {
 		this.postFailureUrl = postFailureUrl;
@@ -179,12 +173,11 @@ public class SpringSocialConfigurer extends SecurityConfigurerAdapter<DefaultSec
 	}
 
 	/**
-	 * Sets the URL to redirect to if authentication fails or if authorization is denied by the user.
-	 * @param defaultFailureUrl the URL to redirect to after an authentication fail or authorization deny
-	 * @return this SpringSocialConfigurer for chained configuration
+	 * @deprecated use {@link #postFailureUrl(String)} instead
 	 */
+	@Deprecated
 	public SpringSocialConfigurer defaultFailureUrl(String defaultFailureUrl) {
-		this.defaultFailureUrl = defaultFailureUrl;
+		postFailureUrl(defaultFailureUrl);
 		return this;
 	}
 	


### PR DESCRIPTION
`setDefaultFailureUrl(..)` and `setPostFailureUrl(..)` do pretty much the same thing. however, one supports `SocialAuthenticationFailureHandler` while the other doesn't. Addtitionally, `delegateAuthenticationFailureHandler` could have been out-of-sync with `authenticationFailureHandler`. With this patch, this is no longer the case.