### PR TITLE
An AuthenticationServiceException is wrongfully thrown when a user is already authenticated with the Authorization Server in SocialAuthenticationFilter

### DIFF
--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
@@ -273,7 +273,7 @@ public class SocialAuthenticationFilter extends AbstractAuthenticationProcessing
 			return doAuthentication(authService, request, token);
 		} else {
 			addConnection(authService, request, token, auth);
-			return null;
+			return auth;
 		}		
 	}	
 	


### PR DESCRIPTION
This fixes #194. I've already signed the contributor's agreement. Thanks!