### PR TITLE
Added support for Redis as a backing datastore for social connections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ configure(allprojects) {
     ]
 
     sourceSets.test.resources.srcDirs = [
-        "src/test/resources", 
+        "src/test/resources",
         "src/test/java"
     ]
 
@@ -148,7 +148,7 @@ configure(subprojects) { subproject ->
         archives javadocJar
     }
 
-    configurations { 
+    configurations {
         springReleaseTestRuntime.extendsFrom testRuntime
         springSnapshotTestRuntime.extendsFrom testRuntime
     }
@@ -195,6 +195,7 @@ project("spring-social-core") {
     description = "Foundational module containing the ServiceProvider Connect Framework and Service API invocation support."
     dependencies {
         compile("org.springframework:spring-jdbc:$springVersion", optional)
+        compile("org.springframework.data:spring-data-redis:$springDataRedisVersion", optional)
         compile("org.springframework:spring-web:$springVersion")
         compile("org.springframework.security:spring-security-crypto:$springSecurityVersion", optional)
         compile("org.apache.httpcomponents:httpclient:$httpComponentsVersion", optional)
@@ -202,6 +203,8 @@ project("spring-social-core") {
         testCompile("org.springframework:spring-test:$springVersion")
         testCompile("javax.servlet:javax.servlet-api:$servletApiVersion", provided)
         testCompile("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+        testCompile("org.apache.commons:commons-pool2:$apacheCommonsPoolVersion")
+        testCompile("redis.clients:jedis:2.8.1")
     }
 }
 
@@ -256,7 +259,7 @@ configure(rootProject) {
 
     dependencies { // for integration tests
     }
-    
+
     task api(type: Javadoc) {
         group = "Documentation"
         description = "Generates aggregated Javadoc API documentation."
@@ -310,7 +313,7 @@ artifacts {
     archives dist
     archives project(':docs').docsZip
     archives project(':docs').schemaZip
-}    
+}
 
     task wrapper(type: Wrapper) {
         gradleVersion = "1.12"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 h2Version=1.3.176
 springSecurityVersion=3.2.9.RELEASE
-springDataRedisVersion=1.7.0.RC1
+springDataRedisVersion=1.7.1.RELEASE
 apacheCommonsPoolVersion=2.2
 junitVersion=4.12
 httpComponentsVersion=4.3.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
 h2Version=1.3.176
 springSecurityVersion=3.2.9.RELEASE
+springDataRedisVersion=1.7.0.RC1
+apacheCommonsPoolVersion=2.2
 junitVersion=4.12
 httpComponentsVersion=4.3.6
 aspectjVersion=1.8.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jun 30 12:43:52 CDT 2014
+#Fri May 27 21:26:51 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip

--- a/spring-social-core/src/main/java/org/springframework/social/connect/redis/RedisConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/redis/RedisConnectionRepository.java
@@ -1,0 +1,175 @@
+package org.springframework.social.connect.redis;
+
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+import org.springframework.social.connect.*;
+import org.springframework.social.connect.redis.data.SocialRedisConnection;
+import org.springframework.social.connect.redis.data.SocialRedisConnectionRepository;
+import org.springframework.util.Assert;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class RedisConnectionRepository implements ConnectionRepository {
+
+    private final ConnectionFactoryLocator connectionFactoryLocator;
+    private final TextEncryptor textEncryptor;
+    private final SocialRedisConnectionRepository socialRedisConnectionRepository;
+    private final String userId;
+
+    public RedisConnectionRepository(final ConnectionFactoryLocator connectionFactoryLocator, final TextEncryptor textEncryptor, final SocialRedisConnectionRepository socialRedisConnectionRepository, final String userId) {
+        Assert.notNull(socialRedisConnectionRepository, "socialRedisConnectionRepository is required");
+        Assert.notNull(userId, "userId is required");
+
+        this.userId = userId;
+        this.socialRedisConnectionRepository = socialRedisConnectionRepository;
+        this.connectionFactoryLocator = connectionFactoryLocator;
+        this.textEncryptor = textEncryptor;
+    }
+
+    public MultiValueMap<String, Connection<?>> findAllConnections() {
+        Iterable<SocialRedisConnection> allConnections = socialRedisConnectionRepository.findByUserId(userId);
+
+        final MultiValueMap<String, Connection<?>> connections = new LinkedMultiValueMap<String, Connection<?>>();
+        Set<String> registeredProviderIds = connectionFactoryLocator.registeredProviderIds();
+        for (String registeredProviderId : registeredProviderIds) {
+            connections.put(registeredProviderId, new ArrayList<Connection<?>>());
+        }
+
+        for (SocialRedisConnection connection : allConnections) {
+            connections.add(connection.getProviderId(), connectionMapper.mapConnection(connection));
+        }
+
+        return connections;
+    }
+
+    public List<Connection<?>> findConnections(String providerId) {
+        Iterable<SocialRedisConnection> connections = socialRedisConnectionRepository.findByProviderId(providerId);
+
+        List<Connection<?>> providerConnections = new ArrayList<Connection<?>>();
+        for (SocialRedisConnection connection : connections) {
+            providerConnections.add(connectionMapper.mapConnection(connection));
+        }
+
+        return providerConnections;
+    }
+
+    public <A> List<Connection<A>> findConnections(Class<A> apiType) {
+        List<?> connections = findConnections(getProviderId(apiType));
+        return (List<Connection<A>>) connections;
+    }
+
+    public MultiValueMap<String, Connection<?>> findConnectionsToUsers(MultiValueMap<String, String> providerUserIds) {
+        return null;
+    }
+
+    public Connection<?> getConnection(ConnectionKey connectionKey) {
+        try {
+            return connectionMapper.mapConnection(socialRedisConnectionRepository.findOneByUserIdAndProviderIdAndProviderUserId(userId, connectionKey.getProviderId(), connectionKey.getProviderUserId()));
+        } catch (EmptyResultDataAccessException e) {
+            throw new NoSuchConnectionException(connectionKey);
+        }
+    }
+
+    public <A> Connection<A> getConnection(Class<A> apiType, String providerUserId) {
+        String providerId = getProviderId(apiType);
+        return (Connection<A>) getConnection(new ConnectionKey(providerId, providerUserId));
+    }
+
+    public <A> Connection<A> getPrimaryConnection(Class<A> apiType) {
+        String providerId = getProviderId(apiType);
+        Connection<A> connection = (Connection<A>) findPrimaryConnection(providerId);
+        if (connection == null) {
+            throw new NotConnectedException(providerId);
+        }
+        return connection;
+    }
+
+    public <A> Connection<A> findPrimaryConnection(Class<A> apiType) {
+        String providerId = getProviderId(apiType);
+        return (Connection<A>) findPrimaryConnection(providerId);
+    }
+
+    public void addConnection(Connection<?> connection) {
+        try {
+            ConnectionData data = connection.createData();
+            SocialRedisConnection redisConnection = new SocialRedisConnection(data.getProviderUserId(), userId, data.getProviderId(), data.getDisplayName(), data.getProfileUrl(), data.getImageUrl(), encrypt(data.getAccessToken()), encrypt(data.getSecret()), encrypt(data.getRefreshToken()), data.getExpireTime());
+            socialRedisConnectionRepository.save(redisConnection);
+        } catch (Exception e) {
+            throw new DuplicateConnectionException(connection.getKey());
+        }
+    }
+
+    public void updateConnection(Connection<?> connection) {
+        ConnectionData data = connection.createData();
+        SocialRedisConnection redisConnection = socialRedisConnectionRepository.findOneByUserIdAndProviderIdAndProviderUserId(userId, data.getProviderId(), data.getProviderUserId());
+
+        redisConnection.setDisplayName(data.getDisplayName());
+        redisConnection.setImageUrl(data.getImageUrl());
+        redisConnection.setProfileUrl(data.getProfileUrl());
+        redisConnection.setAccessToken(encrypt(data.getAccessToken()));
+        redisConnection.setSecret(encrypt(data.getSecret()));
+        redisConnection.setRefreshToken(encrypt(data.getRefreshToken()));
+        redisConnection.setExpireTime(data.getExpireTime());
+
+        socialRedisConnectionRepository.save(redisConnection);
+    }
+
+    public void removeConnections(String providerId) {
+        Iterable<SocialRedisConnection> connections = socialRedisConnectionRepository.findByUserIdAndProviderId(userId, providerId);
+
+        for (SocialRedisConnection redisConnection : connections) {
+            socialRedisConnectionRepository.delete(redisConnection);
+        }
+    }
+
+    public void removeConnection(ConnectionKey connectionKey) {
+        socialRedisConnectionRepository.deleteByUserIdAndProviderIdAndProviderUserId(userId, connectionKey.getProviderId(), connectionKey.getProviderUserId());
+    }
+
+    private final RedisConnectionMapper connectionMapper = new RedisConnectionMapper();
+
+    private final class RedisConnectionMapper {
+
+        Connection<?> mapConnection(final SocialRedisConnection redisConnection) {
+            ConnectionData connectionData = mapConnectionData(redisConnection);
+            ConnectionFactory<?> connectionFactory = connectionFactoryLocator.getConnectionFactory(connectionData.getProviderId());
+            return connectionFactory.createConnection(connectionData);
+        }
+
+        private ConnectionData mapConnectionData(final SocialRedisConnection redisConnection) {
+            return new ConnectionData(redisConnection.getProviderId(), redisConnection.getProviderUserId(), redisConnection.getDisplayName(), redisConnection.getProfileUrl(), redisConnection.getImageUrl(),
+                    decrypt(redisConnection.getAccessToken()), decrypt(redisConnection.getSecret()), decrypt(redisConnection.getRefreshToken()), redisConnection.getExpireTime());
+        }
+
+        private String decrypt(String encryptedText) {
+            return encryptedText == null ? null : textEncryptor.decrypt(encryptedText);
+        }
+    }
+
+    private Connection<?> findPrimaryConnection(String providerId) {
+        Iterable<SocialRedisConnection> redisConnections = socialRedisConnectionRepository.findByUserIdAndProviderId(userId, providerId);
+
+        List<Connection<?>> primaryConnections = new ArrayList<Connection<?>>();
+        for (SocialRedisConnection connection : redisConnections) {
+            primaryConnections.add(connectionMapper.mapConnection(connection));
+        }
+
+        if (primaryConnections.size() > 0) {
+            return primaryConnections.get(0);
+        } else {
+            return null;
+        }
+    }
+
+    private <A> String getProviderId(Class<A> apiType) {
+        return connectionFactoryLocator.getConnectionFactory(apiType).getProviderId();
+    }
+
+    private String encrypt(String text) {
+        return text == null ? null : textEncryptor.encrypt(text);
+    }
+}

--- a/spring-social-core/src/main/java/org/springframework/social/connect/redis/RedisConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/redis/RedisConnectionRepository.java
@@ -127,7 +127,12 @@ public class RedisConnectionRepository implements ConnectionRepository {
     }
 
     public void removeConnection(ConnectionKey connectionKey) {
-        socialRedisConnectionRepository.deleteByUserIdAndProviderIdAndProviderUserId(userId, connectionKey.getProviderId(), connectionKey.getProviderUserId());
+        // TODO: Wait for DATAKV-135 in order to use this:
+        // socialRedisConnectionRepository.deleteByUserIdAndProviderIdAndProviderUserId
+        // (userId, connectionKey.getProviderId(), connectionKey.getProviderUserId());
+
+        SocialRedisConnection socialRedisConnection = socialRedisConnectionRepository.findOneByUserIdAndProviderIdAndProviderUserId(userId, connectionKey.getProviderId(), connectionKey.getProviderUserId());
+        socialRedisConnectionRepository.delete(socialRedisConnection);
     }
 
     private final RedisConnectionMapper connectionMapper = new RedisConnectionMapper();
@@ -135,6 +140,9 @@ public class RedisConnectionRepository implements ConnectionRepository {
     private final class RedisConnectionMapper {
 
         Connection<?> mapConnection(final SocialRedisConnection redisConnection) {
+            if (redisConnection == null) {
+                throw new EmptyResultDataAccessException(1);
+            }
             ConnectionData connectionData = mapConnectionData(redisConnection);
             ConnectionFactory<?> connectionFactory = connectionFactoryLocator.getConnectionFactory(connectionData.getProviderId());
             return connectionFactory.createConnection(connectionData);

--- a/spring-social-core/src/main/java/org/springframework/social/connect/redis/RedisUsersConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/redis/RedisUsersConnectionRepository.java
@@ -1,0 +1,41 @@
+package org.springframework.social.connect.redis;
+
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+import org.springframework.social.connect.Connection;
+import org.springframework.social.connect.ConnectionFactoryLocator;
+import org.springframework.social.connect.ConnectionRepository;
+import org.springframework.social.connect.UsersConnectionRepository;
+import org.springframework.social.connect.redis.data.SocialRedisConnectionRepository;
+import org.springframework.util.Assert;
+
+import java.util.List;
+import java.util.Set;
+
+public class RedisUsersConnectionRepository implements UsersConnectionRepository {
+
+    private final ConnectionFactoryLocator connectionFactoryLocator;
+    private final TextEncryptor textEncryptor;
+    private final SocialRedisConnectionRepository socialRedisConnectionRepository;
+
+    public RedisUsersConnectionRepository(ConnectionFactoryLocator connectionFactoryLocator, TextEncryptor textEncryptor, SocialRedisConnectionRepository socialRedisConnectionRepository) {
+        Assert.notNull(connectionFactoryLocator);
+        Assert.notNull(textEncryptor);
+        Assert.notNull(socialRedisConnectionRepository);
+
+        this.connectionFactoryLocator = connectionFactoryLocator;
+        this.textEncryptor = textEncryptor;
+        this.socialRedisConnectionRepository = socialRedisConnectionRepository;
+    }
+
+    public List<String> findUserIdsWithConnection(final Connection<?> connection) {
+        return null;
+    }
+
+    public Set<String> findUserIdsConnectedTo(final String providerId, final Set<String> providerUserIds) {
+        return null;
+    }
+
+    public ConnectionRepository createConnectionRepository(final String userId) {
+        return null;
+    }
+}

--- a/spring-social-core/src/main/java/org/springframework/social/connect/redis/data/SocialRedisConnection.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/redis/data/SocialRedisConnection.java
@@ -1,0 +1,125 @@
+package org.springframework.social.connect.redis.data;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@RedisHash
+public class SocialRedisConnection {
+
+    @Id
+    private String providerUserId;
+
+    @Indexed
+    private String userId;
+
+    @Indexed
+    private String providerId;
+
+    private String displayName;
+
+    private String profileUrl;
+
+    private String imageUrl;
+
+    private String accessToken;
+
+    private String secret;
+
+    private String refreshToken;
+
+    private Long expireTime;
+
+    public SocialRedisConnection(String providerUserId, String userId, String providerId, String displayName, String profileUrl, String imageUrl, String accessToken, String secret, String refreshToken, Long expireTime) {
+        this.providerUserId = providerUserId;
+        this.userId = userId;
+        this.providerId = providerId;
+        this.displayName = displayName;
+        this.profileUrl = profileUrl;
+        this.imageUrl = imageUrl;
+        this.accessToken = accessToken;
+        this.secret = secret;
+        this.refreshToken = refreshToken;
+        this.expireTime = expireTime;
+    }
+
+    public String getProviderUserId() {
+        return providerUserId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getProfileUrl() {
+        return profileUrl;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public Long getExpireTime() {
+        return expireTime;
+    }
+
+    public void setProviderUserId(String providerUserId) {
+        this.providerUserId = providerUserId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public void setProviderId(String providerId) {
+        this.providerId = providerId;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public void setProfileUrl(String profileUrl) {
+        this.profileUrl = profileUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void setExpireTime(Long expireTime) {
+        this.expireTime = expireTime;
+    }
+}

--- a/spring-social-core/src/main/java/org/springframework/social/connect/redis/data/SocialRedisConnection.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/redis/data/SocialRedisConnection.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.core.index.Indexed;
 public class SocialRedisConnection {
 
     @Id
+    @Indexed
     private String providerUserId;
 
     @Indexed

--- a/spring-social-core/src/main/java/org/springframework/social/connect/redis/data/SocialRedisConnection.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/redis/data/SocialRedisConnection.java
@@ -4,7 +4,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
 
-@RedisHash
+@RedisHash("socialRedisConnection")
 public class SocialRedisConnection {
 
     @Id

--- a/spring-social-core/src/main/java/org/springframework/social/connect/redis/data/SocialRedisConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/redis/data/SocialRedisConnectionRepository.java
@@ -12,6 +12,7 @@ public interface SocialRedisConnectionRepository extends CrudRepository<SocialRe
 
     SocialRedisConnection findOneByUserIdAndProviderIdAndProviderUserId(String userId, String providerId, String providerUserId);
 
+    // TODO: will be available once DATAKV-135 is finished
     void deleteByUserIdAndProviderIdAndProviderUserId(final String userId, final String providerId, final String providerUserId);
 
     Iterable<SocialRedisConnection> findByUserId(final String userId);

--- a/spring-social-core/src/main/java/org/springframework/social/connect/redis/data/SocialRedisConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/redis/data/SocialRedisConnectionRepository.java
@@ -12,10 +12,9 @@ public interface SocialRedisConnectionRepository extends CrudRepository<SocialRe
 
     SocialRedisConnection findOneByUserIdAndProviderIdAndProviderUserId(String userId, String providerId, String providerUserId);
 
-    void deleteByUserIdAndProviderId(final String userId, final String providerId);
-
     void deleteByUserIdAndProviderIdAndProviderUserId(final String userId, final String providerId, final String providerUserId);
 
     Iterable<SocialRedisConnection> findByUserId(final String userId);
 
+    Iterable<SocialRedisConnection> findByProviderIdAndProviderUserId(final String providerId, final String providerUserId);
 }

--- a/spring-social-core/src/main/java/org/springframework/social/connect/redis/data/SocialRedisConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/redis/data/SocialRedisConnectionRepository.java
@@ -1,0 +1,21 @@
+package org.springframework.social.connect.redis.data;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SocialRedisConnectionRepository extends CrudRepository<SocialRedisConnection, String> {
+
+    Iterable<SocialRedisConnection> findByProviderId(final String providerId);
+
+    Iterable<SocialRedisConnection> findByUserIdAndProviderId(final String userId, final String providerId);
+
+    SocialRedisConnection findOneByUserIdAndProviderIdAndProviderUserId(String userId, String providerId, String providerUserId);
+
+    void deleteByUserIdAndProviderId(final String userId, final String providerId);
+
+    void deleteByUserIdAndProviderIdAndProviderUserId(final String userId, final String providerId, final String providerUserId);
+
+    Iterable<SocialRedisConnection> findByUserId(final String userId);
+
+}

--- a/spring-social-core/src/test/java/org/springframework/social/connect/redis/RedisAvailable.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/redis/RedisAvailable.java
@@ -1,0 +1,12 @@
+package org.springframework.social.connect.redis;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+@interface RedisAvailable {
+
+}

--- a/spring-social-core/src/test/java/org/springframework/social/connect/redis/RedisAvailableRule.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/redis/RedisAvailableRule.java
@@ -1,0 +1,70 @@
+package org.springframework.social.connect.redis;
+
+import org.junit.Assume;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+
+class RedisAvailableRule implements TestRule {
+
+    private static ThreadLocal<JedisConnectionFactory> connectionFactoryResource = new ThreadLocal<>();
+
+    private String redisHost;
+
+    private int redisPort;
+
+    RedisAvailableRule(final String redisHost, final int redisPort) {
+        this.redisHost = redisHost;
+        this.redisPort = redisPort;
+    }
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        RedisAvailable redisAvailable = description.getAnnotation(RedisAvailable.class);
+        if (redisAvailable != null) {
+            JedisConnectionFactory connectionFactory = null;
+            try {
+                connectionFactory = new JedisConnectionFactory();
+                connectionFactory.setHostName(redisHost);
+                connectionFactory.setPort(redisPort);
+                connectionFactory.afterPropertiesSet();
+                connectionFactory.getConnection();
+                connectionFactoryResource.set(connectionFactory);
+            } catch (Exception e) {
+                if (connectionFactory != null) {
+                    connectionFactory.destroy();
+                }
+                return new Statement() {
+                    @Override
+                    public void evaluate() throws Throwable {
+                        Assume.assumeTrue("Skipping test class: Redis not available at port " + redisHost + ":" + redisPort, false);
+                    }
+                };
+            }
+
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    try {
+                        base.evaluate();
+                    } finally {
+                        JedisConnectionFactory connectionFactory = connectionFactoryResource.get();
+                        connectionFactoryResource.remove();
+                        if (connectionFactory != null) {
+                            connectionFactory.destroy();
+                        }
+                    }
+                }
+            };
+        }
+
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                base.evaluate();
+            }
+        };
+
+    }
+}

--- a/spring-social-core/src/test/java/org/springframework/social/connect/redis/RedisConnectionRepositoryIntegrationTests.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/redis/RedisConnectionRepositoryIntegrationTests.java
@@ -1,0 +1,182 @@
+package org.springframework.social.connect.redis;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.security.crypto.encrypt.Encryptors;
+import org.springframework.social.connect.*;
+import org.springframework.social.connect.redis.data.SocialRedisConnectionRepository;
+import org.springframework.social.connect.support.AbstractConnection;
+import org.springframework.social.connect.support.ConnectionFactoryRegistry;
+import org.springframework.social.connect.support.OAuth1ConnectionFactory;
+import org.springframework.social.oauth1.OAuth1Operations;
+import org.springframework.social.oauth1.OAuth1ServiceProvider;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.util.MultiValueMap;
+import redis.clients.jedis.JedisShardInfo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+@RedisAvailable
+public class RedisConnectionRepositoryIntegrationTests {
+
+    private static final String REDIS_HOST = "127.0.0.1";
+    private static final int REDIS_PORT = 6379;
+
+    @ClassRule
+    public static TestRule redisAvailableRule = new RedisAvailableRule(REDIS_HOST, REDIS_PORT);
+
+    @Autowired
+    @SuppressWarnings("SpringJavaAutowiringInspection")
+    private SocialRedisConnectionRepository socialRedisConnectionRepository;
+
+    @Autowired
+    private ConnectionFactoryLocator connectionFactoryLocator;
+
+    private RedisConnectionRepository redisConnectionRepository;
+
+    private TestConnection testConnection;
+
+    @Before
+    public void init() {
+        redisConnectionRepository = new RedisConnectionRepository(connectionFactoryLocator, Encryptors.noOpText(), socialRedisConnectionRepository, "Turbots");
+        testConnection = new TestConnection(new TestTwitterApiAdapter());
+        socialRedisConnectionRepository.deleteAll();
+    }
+
+    @Test
+    public void addConnection() {
+        redisConnectionRepository.addConnection(testConnection);
+
+        MultiValueMap<String, Connection<?>> map = redisConnectionRepository.findAllConnections();
+
+        assertEquals(1, map.get("twitter").size());
+    }
+
+    @Test
+    public void removeConnections() {
+        redisConnectionRepository.addConnection(testConnection);
+
+        redisConnectionRepository.removeConnections("twitter");
+
+        MultiValueMap<String, Connection<?>> map = redisConnectionRepository.findAllConnections();
+
+        assertEquals(0, map.get("twitter").size());
+    }
+
+    @Test
+    public void findPrimaryConnection() {
+        redisConnectionRepository.addConnection(testConnection);
+
+        Connection<TestTwitterApi> connection = redisConnectionRepository.findPrimaryConnection(TestTwitterApi.class);
+
+        assertNotNull(connection);
+        assertEquals(connection.getDisplayName(), "displayName");
+    }
+
+    @Configuration
+    @EnableRedisRepositories(includeFilters = {@ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*SocialRedisConnectionRepository")})
+    static class Config {
+
+        @Bean
+        RedisTemplate<?, ?> redisTemplate() {
+            JedisConnectionFactory connectionFactory = new JedisConnectionFactory(new JedisShardInfo(REDIS_HOST, REDIS_PORT));
+            connectionFactory.afterPropertiesSet();
+
+            RedisTemplate<byte[], byte[]> template = new RedisTemplate<>();
+            template.setConnectionFactory(connectionFactory);
+
+            return template;
+        }
+
+        @Bean
+        public ConnectionFactoryLocator connectionFactoryLocator() {
+            ConnectionFactoryRegistry registry = new ConnectionFactoryRegistry();
+            registry.addConnectionFactory(new TestTwitterConnectionFactory());
+            return registry;
+        }
+    }
+
+    class TestConnection extends AbstractConnection {
+
+        TestConnection(ApiAdapter apiAdapter) {
+            //noinspection unchecked
+            super(apiAdapter);
+        }
+
+        @Override
+        public Object getApi() {
+            return "twitter";
+        }
+
+        @Override
+        public ConnectionData createData() {
+            return new ConnectionData("twitter", "providerUserId", "displayName", "profileUrl", "imageUrl", "accessToken", "secret", "refreshToken", 1000000L);
+        }
+    }
+
+    private static class TestTwitterConnectionFactory extends OAuth1ConnectionFactory<TestTwitterApi> {
+
+        public TestTwitterConnectionFactory() {
+            super("twitter", new TestTwitterServiceProvider(), new TestTwitterApiAdapter());
+        }
+
+    }
+
+    private static class TestTwitterServiceProvider implements OAuth1ServiceProvider<TestTwitterApi> {
+
+        public OAuth1Operations getOAuthOperations() {
+            return null;
+        }
+
+        public TestTwitterApi getApi(final String accessToken, final String secret) {
+            return new TestTwitterApi() {
+                public String getAccessToken() {
+                    return accessToken;
+                }
+
+            };
+        }
+
+    }
+
+    public interface TestTwitterApi {
+
+        String getAccessToken();
+
+    }
+
+    private static class TestTwitterApiAdapter implements ApiAdapter<TestTwitterApi> {
+
+        private String name = "@dhubau";
+
+        public boolean test(TestTwitterApi api) {
+            return true;
+        }
+
+        public void setConnectionValues(TestTwitterApi api, ConnectionValues values) {
+        }
+
+        public UserProfile fetchUserProfile(TestTwitterApi api) {
+            return new UserProfileBuilder().setName(name).setUsername(name).build();
+        }
+
+        public void updateStatus(TestTwitterApi api, String message) {
+        }
+
+    }
+}

--- a/spring-social-core/src/test/java/org/springframework/social/connect/redis/RedisUtils.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/redis/RedisUtils.java
@@ -1,0 +1,87 @@
+package org.springframework.social.connect.redis;
+
+import org.springframework.social.connect.*;
+import org.springframework.social.connect.support.AbstractConnection;
+import org.springframework.social.connect.support.OAuth1ConnectionFactory;
+import org.springframework.social.oauth1.OAuth1Operations;
+import org.springframework.social.oauth1.OAuth1ServiceProvider;
+
+class RedisUtils {
+
+    static class TestConnection extends AbstractConnection {
+
+        private String providerUserId;
+
+        TestConnection(final ApiAdapter apiAdapter, final String providerUserId) {
+            //noinspection unchecked
+            super(apiAdapter);
+            this.providerUserId = providerUserId;
+        }
+
+        @Override
+        public Object getApi() {
+            return "twitter";
+        }
+
+        @Override
+        public ConnectionKey getKey() {
+            return new ConnectionKey("twitter", providerUserId);
+        }
+
+        @Override
+        public ConnectionData createData() {
+            return new ConnectionData("twitter", providerUserId, "displayName", "profileUrl", "imageUrl", "accessToken", "secret", "refreshToken", 1000000L);
+        }
+    }
+
+    static class TestTwitterConnectionFactory extends OAuth1ConnectionFactory<TestTwitterApi> {
+
+        TestTwitterConnectionFactory() {
+            super("twitter", new TestTwitterServiceProvider(), new TestTwitterApiAdapter());
+        }
+
+    }
+
+    private static class TestTwitterServiceProvider implements OAuth1ServiceProvider<TestTwitterApi> {
+
+        public OAuth1Operations getOAuthOperations() {
+            return null;
+        }
+
+        public TestTwitterApi getApi(final String accessToken, final String secret) {
+            return new TestTwitterApi() {
+                public String getAccessToken() {
+                    return accessToken;
+                }
+
+            };
+        }
+
+    }
+
+    interface TestTwitterApi {
+
+        String getAccessToken();
+
+    }
+
+    static class TestTwitterApiAdapter implements ApiAdapter<TestTwitterApi> {
+
+        private String name = "@dhubau";
+
+        public boolean test(TestTwitterApi api) {
+            return true;
+        }
+
+        public void setConnectionValues(TestTwitterApi api, ConnectionValues values) {
+        }
+
+        public UserProfile fetchUserProfile(TestTwitterApi api) {
+            return new UserProfileBuilder().setName(name).setUsername(name).build();
+        }
+
+        public void updateStatus(TestTwitterApi api, String message) {
+        }
+
+    }
+}

--- a/spring-social-core/src/test/java/org/springframework/social/connect/redis/RedisUtils.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/redis/RedisUtils.java
@@ -13,14 +13,18 @@ class RedisUtils {
         private String providerUserId;
 
         TestConnection(final ApiAdapter apiAdapter, final String providerUserId) {
-            //noinspection unchecked
             super(apiAdapter);
             this.providerUserId = providerUserId;
         }
 
         @Override
         public Object getApi() {
-            return "twitter";
+            return new TestTwitterApi() {
+                @Override
+                public String getAccessToken() {
+                    return "accessToken-123";
+                }
+            };
         }
 
         @Override


### PR DESCRIPTION
This is my first commit for the Redis backed datastore for social connections. It uses the `1.7.0.RC1` release of `spring-data-redis` which enables support for **Redis repositories**. Maybe we should wait for `spring-data-redis-1.7.0.RELEASE` but I wanted to get it out there asap :baby: 

There are still some unit tests to be performed and I need to implement one final method of the, namely: 
```
findConnectionsToUsers()
```
Also, I'm still not sure about the names of my classes, could someone maybe recommend more suitable names?

Thank you for commenting/contributing/improving my code :yum: 