### PR TITLE
handle empty result by access token endpoint, fixes #203

### DIFF
--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Template.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Template.java
@@ -35,6 +35,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -239,7 +240,11 @@ public class OAuth2Template implements OAuth2Operations {
 	 */
 	@SuppressWarnings("unchecked")
 	protected AccessGrant postForAccessGrant(String accessTokenUrl, MultiValueMap<String, String> parameters) {
-		return extractAccessGrant(getRestTemplate().postForObject(accessTokenUrl, parameters, Map.class));
+		Map<String, Object> result = getRestTemplate().postForObject(accessTokenUrl, parameters, Map.class);
+		if (result == null) {
+			throw new RestClientException("access token endpoint returned empty result");
+		}
+		return extractAccessGrant(result);
 	}
 	
 	/**


### PR DESCRIPTION
I looked into #203 a little further as we still see some of these in our logs. This is the code in question:

```java
private AccessGrant extractAccessGrant(Map<String, Object> result) {
	return createAccessGrant((String) result.get("access_token"), (String) result.get("scope"), (String) result.get("refresh_token"), getIntegerValue(result, "expires_in"), result);
}

protected AccessGrant postForAccessGrant(String accessTokenUrl, MultiValueMap<String, String> parameters) {
	return extractAccessGrant(getRestTemplate().postForObject(accessTokenUrl, parameters, Map.class));
}
```

so the problem is that `postForObject(..)` returns `null` instead of a `Map`. The `LoggingErrorHandler` is supposed to throw an exception for 4xx and 5xx status codes and the [standard](https://tools.ietf.org/html/rfc6749#section-5.2) requires a `400 Bad Request` for all errors. So this seems to be on Facebook sending an illegal empty response following an access token request.

The code should still be able to cope with this better than with an NPE. I've chosen to use a `RestClientException` as if the request failed completely.