### PR TITLE
JdbcConnectionRepository does not work with Spring Boot DevTools

### DIFF
--- a/spring-social-core/src/main/java/org/springframework/social/connect/jdbc/JdbcConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/jdbc/JdbcConnectionRepository.java
@@ -45,7 +45,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-class JdbcConnectionRepository implements ConnectionRepository {
+public class JdbcConnectionRepository implements ConnectionRepository {
 
 	private final String userId;
 	

--- a/spring-social-core/src/main/java/org/springframework/social/connect/mem/InMemoryConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/mem/InMemoryConnectionRepository.java
@@ -30,7 +30,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-class InMemoryConnectionRepository implements ConnectionRepository {
+public class InMemoryConnectionRepository implements ConnectionRepository {
 
 	// <providerId, Connection<provider API>>
 	private MultiValueMap<String, Connection<?>> connections;


### PR DESCRIPTION
JdbcConnectionRepository uses @ Transactional and thus creates a proxy using the restart class loader in Spring Boot DevTools. Because JdbcConnectionRepository is package private an exception is raised upon creation:

```
java.lang.IllegalAccessError: class org.springframework.social.connect.jdbc.JdbcConnectionRepository$$EnhancerBySpringCGLIB$$df73938 cannot access its superclass org.springframework.social.connect.jdbc.JdbcConnectionRepository
	at java.lang.ClassLoader.defineClass1(Native Method) ~[na:1.8.0_72]
	at java.lang.ClassLoader.defineClass(ClassLoader.java:760) ~[na:1.8.0_72]
	at sun.reflect.GeneratedMethodAccessor22.invoke(Unknown Source) ~[na:na]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_72]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_72]
	at org.springframework.cglib.core.ReflectUtils.defineClass(ReflectUtils.java:413) ~[spring-core-4.3.3.RELEASE.jar:4.3.3.RELEASE]
	at org.springframework.cglib.core.AbstractClassGenerator.generate(AbstractClassGenerator.java:336) ~[spring-core-4.3.3.RELEASE.jar:4.3.3.RELEASE]
	at org.springframework.cglib.proxy.Enhancer.generate(Enhancer.java:492) ~[spring-core-4.3.3.RELEASE.jar:4.3.3.RELEASE]
	at org.springframework.cglib.core.AbstractClassGenerator$ClassLoaderData$3.apply(AbstractClassGenerator.java:93) ~[spring-core-4.3.3.RELEASE.jar:4.3.3.RELEASE]
	at org.springframework.cglib.core.AbstractClassGenerator$ClassLoaderData$3.apply(AbstractClassGenerator.java:91) ~[spring-core-4.3.3.RELEASE.jar:4.3.3.RELEASE]
	at org.springframework.cglib.core.internal.LoadingCache$2.call(LoadingCache.java:54) ~[spring-core-4.3.3.RELEASE.jar:4.3.3.RELEASE]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[na:1.8.0_72]
	at org.springframework.cglib.core.internal.LoadingCache.createEntry(LoadingCache.java:61) ~[spring-core-4.3.3.RELEASE.jar:4.3.3.RELEASE]
	at org.springframework.cglib.core.internal.LoadingCache.get(LoadingCache.java:34) ~[spring-core-4.3.3.RELEASE.jar:4.3.3.RELEASE]
	...
```

If you want to use Spring Social with the JdbcConnectionRepository implementation, I see no other way than to make the ConnectionRepository implementations public. One can also argue that they should be public as they are exposed as public beans in the `org.springframework.social.config.annotation.SocialConfiguration` configuration class (the connectionRepository bean).

The InMemoryConnectionRepository does not create any proxies and thus does not suffer from the same issue, but I though that it should also be public for consistency.