### PR TITLE
Use thymeleaf-spring5 to align with Spring Framework version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ configure(allprojects) {
     ]
 
     sourceSets.test.resources.srcDirs = [
-        "src/test/resources", 
+        "src/test/resources",
         "src/test/java"
     ]
 
@@ -151,7 +151,7 @@ configure(subprojects) { subproject ->
         archives javadocJar
     }
 
-    configurations { 
+    configurations {
         springReleaseTestRuntime.extendsFrom testRuntime
         springSnapshotTestRuntime.extendsFrom testRuntime
     }
@@ -227,7 +227,7 @@ project("spring-social-web-thymeleaf3") {
     dependencies {
         compile project(":spring-social-core")
         compile("org.thymeleaf:thymeleaf:$thymeleaf3Version")
-        compile("org.thymeleaf:thymeleaf-spring4:$thymeleaf3Version")
+        compile("org.thymeleaf:thymeleaf-spring5:$thymeleafSpring5Version")
         testCompile("org.springframework:spring-test:$springVersion")
     }
 }
@@ -266,7 +266,7 @@ configure(rootProject) {
 
     dependencies { // for integration tests
     }
-    
+
     task api(type: Javadoc) {
         group = "Documentation"
         description = "Generates aggregated Javadoc API documentation."
@@ -320,7 +320,7 @@ artifacts {
     archives dist
     archives project(':docs').docsZip
     archives project(':docs').schemaZip
-}    
+}
 
     task wrapper(type: Wrapper) {
         gradleVersion = "3.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,4 @@ springReleaseVersion=latest.release
 mockitoVersion=2.1.0
 javaxInjectVersion=1
 thymeleaf3Version=3.0.3.RELEASE
+thymeleafSpring5Version=3.0.3.M1

--- a/spring-social-web-thymeleaf3/src/main/java/org/springframework/social/connect/web/thymeleaf/ConnectedAttrProcessor.java
+++ b/spring-social-web-thymeleaf3/src/main/java/org/springframework/social/connect/web/thymeleaf/ConnectedAttrProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import org.thymeleaf.engine.AttributeName;
 import org.thymeleaf.exceptions.ConfigurationException;
 import org.thymeleaf.model.IProcessableElementTag;
 import org.thymeleaf.processor.IProcessor;
-import org.thymeleaf.spring4.context.SpringContextUtils;
+import org.thymeleaf.spring5.context.SpringContextUtils;
 import org.thymeleaf.standard.processor.AbstractStandardConditionalVisibilityTagProcessor;
 import org.thymeleaf.templatemode.TemplateMode;
 


### PR DESCRIPTION
Replace dependency on thymeleaf-spring4 with a dependency on
thymeleaf-spring5 to align with the project's Spring Framework
dependency.