### PR TITLE
Fixes #226 - Configure filterProcessesUrl via SpringSocialConfigurer

### DIFF
--- a/spring-social-security/src/main/java/org/springframework/social/security/SpringSocialConfigurer.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SpringSocialConfigurer.java
@@ -53,6 +53,8 @@ public class SpringSocialConfigurer extends SecurityConfigurerAdapter<DefaultSec
 
 	private String connectionAddedRedirectUrl;
 
+	private String filterProcessesUrl;
+
 	private boolean alwaysUsePostLoginUrl = false;
 
 	/**
@@ -97,7 +99,11 @@ public class SpringSocialConfigurer extends SecurityConfigurerAdapter<DefaultSec
 		if (connectionAddedRedirectUrl != null) {
 			filter.setConnectionAddedRedirectUrl(connectionAddedRedirectUrl);
 		}
-		
+
+		if (filterProcessesUrl != null) {
+			filter.setFilterProcessesUrl(filterProcessesUrl);
+		}
+
 		http.authenticationProvider(
 				new SocialAuthenticationProvider(usersConnectionRepository, socialUsersDetailsService))
 			.addFilterBefore(postProcess(filter), AbstractPreAuthenticatedProcessingFilter.class);
@@ -172,4 +178,13 @@ public class SpringSocialConfigurer extends SecurityConfigurerAdapter<DefaultSec
 		return this;
 	}
 
+	/**
+	 * Sets the URL that determines if social authentication is required.
+	 * @param filterProcessesUrl the URL that will initiate the social authentication process
+	 * @return this SpringSocialConfigurer for chained configuration
+	 */
+	public SpringSocialConfigurer filterProcessesUrl(String filterProcessesUrl) {
+		this.filterProcessesUrl = filterProcessesUrl;
+		return this;
+	}
 }

--- a/spring-social-security/src/test/java/org/springframework/social/security/SpringSocialConfigurerTest.java
+++ b/spring-social-security/src/test/java/org/springframework/social/security/SpringSocialConfigurerTest.java
@@ -1,0 +1,106 @@
+package org.springframework.social.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.mockito.Mockito.mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.social.connect.UsersConnectionRepository;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Florian Lopes
+ */
+@RunWith(SpringRunner.class)
+public class SpringSocialConfigurerTest {
+
+	@Autowired
+	private FilterChainProxy springSecurityFilterChain;
+
+	@Autowired
+	private UsersConnectionRepository usersConnectionRepository;
+
+	@Autowired
+	private SocialAuthenticationServiceLocator socialAuthenticationServiceLocator;
+
+	@Test
+	public void testConfigure() {
+		final SecurityFilterChain defaultFilterChain = this.springSecurityFilterChain.getFilterChains().get(0);
+		assertTrue(defaultFilterChain.getFilters().stream().anyMatch(filter -> filter instanceof SocialAuthenticationFilter));
+
+		final SocialAuthenticationFilter socialAuthenticationFilter =
+				(SocialAuthenticationFilter) defaultFilterChain.getFilters()
+						.stream().filter(filter -> filter instanceof SocialAuthenticationFilter).findFirst().orElse(null);
+		assertNotNull(socialAuthenticationFilter);
+
+		assertTrue(ReflectionTestUtils.getField(socialAuthenticationFilter, "userIdSource") instanceof AuthenticationNameUserIdSource);
+
+		final ProviderManager providerManager =
+				(ProviderManager) ReflectionTestUtils.getField(socialAuthenticationFilter, "authenticationManager");
+		assertTrue(providerManager.getProviders().stream().anyMatch(authenticationProvider -> authenticationProvider instanceof SocialAuthenticationProvider));
+
+		assertNotNull(ReflectionTestUtils.getField(socialAuthenticationFilter, "rememberMeServices"));
+		final SocialAuthenticationFailureHandler failureHandler =
+				(SocialAuthenticationFailureHandler) ReflectionTestUtils.getField(socialAuthenticationFilter, "failureHandler");
+
+		assertEquals("/postFailure", ReflectionTestUtils.getField(failureHandler.getDelegate(), "defaultFailureUrl"));
+		final AuthenticationSuccessHandler successHandler =
+				(AuthenticationSuccessHandler) ReflectionTestUtils.getField(socialAuthenticationFilter, "successHandler");
+		assertEquals("/postLogin", ReflectionTestUtils.getField(successHandler, "defaultTargetUrl"));
+		assertEquals("/social-login", ReflectionTestUtils.getField(socialAuthenticationFilter, "filterProcessesUrl"));
+		assertEquals("/connectionAdded", ReflectionTestUtils.getField(socialAuthenticationFilter, "connectionAddedRedirectUrl"));
+		assertEquals("/signup", ReflectionTestUtils.getField(socialAuthenticationFilter, "signupUrl"));
+
+		assertSame(this.usersConnectionRepository, socialAuthenticationFilter.getUsersConnectionRepository());
+		assertSame(this.socialAuthenticationServiceLocator, socialAuthenticationFilter.getAuthServiceLocator());
+	}
+
+	@EnableWebSecurity
+	@Configuration
+	static class SpringSocialSecurityConfig extends WebSecurityConfigurerAdapter {
+
+		// @formatter:off
+		@Override
+		protected void configure(HttpSecurity http) throws Exception {
+			http
+				.rememberMe()
+				.and()
+					.apply(new SpringSocialConfigurer()
+							.userIdSource(new AuthenticationNameUserIdSource())
+							.postLoginUrl("/postLogin")
+							.postFailureUrl("/postFailure")
+							.signupUrl("/signup")
+							.connectionAddedRedirectUrl("/connectionAdded")
+							.filterProcessesUrl("/social-login"));
+		}
+		// @formatter:on
+
+		@Bean
+		public UsersConnectionRepository usersConnectionRepository() {
+			return mock(UsersConnectionRepository.class);
+		}
+
+		@Bean
+		public SocialUserDetailsService socialUserDetailsService() {
+			return mock(SocialUserDetailsService.class);
+		}
+
+		@Bean
+		public SocialAuthenticationServiceLocator socialAuthenticationServiceLocator() {
+			return mock(SocialAuthenticationServiceLocator.class);
+		}
+	}
+}


### PR DESCRIPTION
Fixes #226 : Make filterProcessesUrl of SocialAuthenticationFilter configurable via SpringSocialConfigurer
- Add the ability to configure filterProcessesUrl of SocialAuthenticationFilter
via SpringSocialConfigurer
- Add SpringSocialConfigurer#configure test

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
