### PR TITLE
Correctly append client_id to URLs with query strings

### DIFF
--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Template.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Template.java
@@ -31,6 +31,7 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.social.support.ClientHttpRequestFactorySelector;
 import org.springframework.social.support.FormMapHttpMessageConverter;
 import org.springframework.social.support.LoggingErrorHandler;
+import org.springframework.social.support.URIBuilder;
 import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -85,10 +86,9 @@ public class OAuth2Template implements OAuth2Operations {
 		Assert.notNull(accessTokenUrl, "The accessTokenUrl property cannot be null");
 		this.clientId = clientId;
 		this.clientSecret = clientSecret;
-		String clientInfo = "?client_id=" + formEncode(clientId);
-		this.authorizeUrl = authorizeUrl + clientInfo;
+		this.authorizeUrl = URIBuilder.fromUri(authorizeUrl).queryParam("client_id", clientId).build().toString();
 		if (authenticateUrl != null) {
-			this.authenticateUrl = authenticateUrl + clientInfo;
+			this.authenticateUrl = URIBuilder.fromUri(authenticateUrl).queryParam("client_id", clientId).build().toString();
 		} else {
 			this.authenticateUrl = null;
 		}

--- a/spring-social-core/src/test/java/org/springframework/social/oauth2/OAuth2TemplateTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/oauth2/OAuth2TemplateTest.java
@@ -36,16 +36,22 @@ public class OAuth2TemplateTest {
 
 	private static final String AUTHORIZE_URL = "http://www.someprovider.com/oauth/authorize";
 
+	private static final String AUTHORIZE_URL_WITH_QUERY = "http://www.someprovider.com/oauth/authorize?foo=bar";
+
+	private static final String AUTHENTICATE_URL_WITH_QUERY = "http://www.someprovider.com/oauth/authenticate?foo=bar";
+
 	private static final String ACCESS_TOKEN_URL = "http://www.someprovider.com/oauth/accessToken";
 
 	private OAuth2Template oAuth2Template;
 	private OAuth2Template oAuth2TemplateParamBased;
+	private OAuth2Template oAuth2TemplateWithQuery;
 
 	@Before
 	public void setup() {
 		oAuth2Template = new OAuth2Template("client_id", "client_secret", AUTHORIZE_URL, null, ACCESS_TOKEN_URL);
 		oAuth2TemplateParamBased = new OAuth2Template("client_id", "client_secret", AUTHORIZE_URL, null, ACCESS_TOKEN_URL);
 		oAuth2TemplateParamBased.setUseParametersForClientAuthentication(true);
+		oAuth2TemplateWithQuery = new OAuth2Template("client_id", "client_secret", AUTHORIZE_URL_WITH_QUERY, AUTHENTICATE_URL_WITH_QUERY, ACCESS_TOKEN_URL);
 	}
 
 	@Test
@@ -90,6 +96,24 @@ public class OAuth2TemplateTest {
 		assertEquals(expected, actual);
 	}
 
+	@Test
+	public void buildAuthorizeUrl_withQuery() {
+		OAuth2Parameters parameters = new OAuth2Parameters();
+		parameters.setRedirectUri("http://www.someclient.com/connect/foo");
+		String expected = AUTHORIZE_URL_WITH_QUERY + "&client_id=client_id&response_type=code&redirect_uri=http%3A%2F%2Fwww.someclient.com%2Fconnect%2Ffoo";
+		String actual = oAuth2TemplateWithQuery.buildAuthorizeUrl(parameters);
+		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void buildAuthenticateUrl_withQuery() {
+		OAuth2Parameters parameters = new OAuth2Parameters();
+		parameters.setRedirectUri("http://www.someclient.com/connect/foo");
+		String expected = AUTHENTICATE_URL_WITH_QUERY + "&client_id=client_id&response_type=code&redirect_uri=http%3A%2F%2Fwww.someclient.com%2Fconnect%2Ffoo";
+		String actual = oAuth2TemplateWithQuery.buildAuthenticateUrl(parameters);
+		assertEquals(expected, actual);
+	}
+	
 	@Test
 	public void exchangeForAccess_jsonResponse() {
 		AccessGrant accessGrant = getAccessGrant("accessToken.json");


### PR DESCRIPTION
`OAuth2Template` currently assumes that `authorizeUrl` and `authenticateUrl` do not contain query strings. If they do, then they end up containing 2 x `?`.

This PR fixes that by using `URIBuilder` to properly append the `client_id` query parameter to the base URLs.