### PR TITLE
Fixes "401 from Twitter"

### DIFF
--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/SigningSupport.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/SigningSupport.java
@@ -45,6 +45,10 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 
+/**
+  * @Author Michael Wirth
+  */
+
 class SigningSupport {
 	
 	private TimestampGenerator timestampGenerator = new DefaultTimestampGenerator();
@@ -188,7 +192,7 @@ class SigningSupport {
 	}
 
 	private MultiValueMap<String, String> readFormParameters(MediaType bodyType, byte[] bodyBytes) {
-		if (bodyType != null && bodyType.equals(MediaType.APPLICATION_FORM_URLENCODED)) {
+		if (MediaType.APPLICATION_FORM_URLENCODED.isCompatibleWith(bodyType)) {
 			String body;
 			try {
 				body = new String(bodyBytes, UTF8_CHARSET_NAME);
@@ -200,7 +204,7 @@ class SigningSupport {
 			return EmptyMultiValueMap.instance();
 		}
 	}
-	
+
 	private MultiValueMap<String, String> parseFormParameters(String parameterString) {
 		if (parameterString == null || parameterString.length() == 0) {
 			return EmptyMultiValueMap.instance();


### PR DESCRIPTION
-  https://github.com/spring-projects/spring-social-twitter/issues/125

spring-social-twitter fails to authenticate because of a bug in the SigningSupport class. 
The RestTemplate set the Content-Type to "application/x-www-form-urlencoded;charset=UTF-8", but the SigningSupport class uses `bodyType.equals(MediaType.APPLICATION_FORM_URLENCODED)` instead of "isCompatibleWith".
