### PR TITLE
No need to manually force port 80 when X-Forwarded-Port is not specif…

### DIFF
--- a/spring-social-security/src/main/java/org/springframework/social/security/provider/OAuth2AuthenticationService.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/provider/OAuth2AuthenticationService.java
@@ -138,7 +138,7 @@ public class OAuth2AuthenticationService<S> extends AbstractSocialAuthentication
 		String schemeHeader = request.getHeader("X-Forwarded-Proto");
 		String portHeader = request.getHeader("X-Forwarded-Port");
 		String scheme = StringUtils.isEmpty(schemeHeader) ? "http" : schemeHeader;
-		String port = StringUtils.isEmpty(portHeader) ? "80" : portHeader;
+		String port = StringUtils.isEmpty(portHeader) ? "" : portHeader;
 		if (scheme.equals("http") && port.equals("80")){
 			port = "";
 		}


### PR DESCRIPTION
…ied.  This results in a bug when having X-Forwarded-Proto as https and X-Forwarded-Port not specified. It will produce a URL with https and port 80 appended at the end.  This bug is prevelant on the most current App Engine Java Flexible environment. It specified the scheme, but no port which causes the code to fail and redirect to a non-existant url.

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
