### PR TITLE
URL Cleanup

### DIFF
--- a/spring-social-config/src/test/resources/org/springframework/social/config/xml/SocialConfigNamespaceTest-context.xml
+++ b/spring-social-config/src/test/resources/org/springframework/social/config/xml/SocialConfigNamespaceTest-context.xml
@@ -6,12 +6,12 @@
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd
-		http://www.springframework.org/schema/social http://www.springframework.org/schema/social/spring-social.xsd
-		http://www.springframework.org/schema/social/fake http://www.springframework.org/schema/social/spring-social-fake.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-3.1.xsd
+		http://www.springframework.org/schema/social https://www.springframework.org/schema/social/spring-social.xsd
+		http://www.springframework.org/schema/social/fake https://www.springframework.org/schema/social/spring-social-fake.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 	<!-- SET UP SOME CONNECTION FACTORIES -->
  	<social:jdbc-connection-repository connection-signup-ref="connectionSignUp" />

--- a/spring-social-core/src/main/java/sql-error-codes.xml
+++ b/spring-social-core/src/main/java/sql-error-codes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "http://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <!--
     - Overrides default error codes for H2 to account for new error code


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.springframework.org/schema/social/spring-social-fake.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/social/spring-social-fake.xsd ([https](https://www.springframework.org/schema/social/spring-social-fake.xsd) result 404).
* http://www.springframework.org/schema/social/spring-social.xsd (404) with 1 occurrences migrated to:  
  https://www.springframework.org/schema/social/spring-social.xsd ([https](https://www.springframework.org/schema/social/spring-social.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.springframework.org/dtd/spring-beans-2.0.dtd with 1 occurrences migrated to:  
  https://www.springframework.org/dtd/spring-beans-2.0.dtd ([https](https://www.springframework.org/dtd/spring-beans-2.0.dtd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.1.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.1.xsd) result 200).
* http://www.springframework.org/schema/jdbc/spring-jdbc.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/jdbc/spring-jdbc.xsd ([https](https://www.springframework.org/schema/jdbc/spring-jdbc.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util-3.1.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util-3.1.xsd ([https](https://www.springframework.org/schema/util/spring-util-3.1.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://jakarta.apache.org/log4j/ with 1 occurrences
* http://www.springframework.org/schema/beans with 2 occurrences
* http://www.springframework.org/schema/context with 2 occurrences
* http://www.springframework.org/schema/jdbc with 2 occurrences
* http://www.springframework.org/schema/social with 2 occurrences
* http://www.springframework.org/schema/social/fake with 2 occurrences
* http://www.springframework.org/schema/util with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences