### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -179,4 +179,4 @@ $ ./gradlew idea
 [sts]: https://spring.io/tools
 [Pull requests]: http://help.github.com/send-pull-requests
 [contributor guidelines]: https://github.com/spring-projects/spring-framework/blob/master/CONTRIBUTING.md
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/docs/manual/src/asciidoc/resources/xsl/html-custom.xsl
+++ b/docs/manual/src/asciidoc/resources/xsl/html-custom.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/docs/manual/src/asciidoc/resources/xsl/html-single-custom.xsl
+++ b/docs/manual/src/asciidoc/resources/xsl/html-single-custom.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/docs/manual/src/asciidoc/resources/xsl/pdf-custom.xsl
+++ b/docs/manual/src/asciidoc/resources/xsl/pdf-custom.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/spring-social-config/src/main/java/org/springframework/social/config/annotation/ConnectionFactoryConfigurer.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/annotation/ConnectionFactoryConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/annotation/DefaultConnectionFactoryConfigurer.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/annotation/DefaultConnectionFactoryConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/annotation/EnableSocial.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/annotation/EnableSocial.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/annotation/SecurityEnabledConnectionFactoryConfigurer.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/annotation/SecurityEnabledConnectionFactoryConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/annotation/SocialConfiguration.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/annotation/SocialConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/annotation/SocialConfigurer.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/annotation/SocialConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/annotation/SocialConfigurerAdapter.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/annotation/SocialConfigurerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/support/AbstractConnectionRepositoryConfigSupport.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/support/AbstractConnectionRepositoryConfigSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/support/InMemoryConnectionRepositoryConfigSupport.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/support/InMemoryConnectionRepositoryConfigSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/support/JdbcConnectionRepositoryConfigSupport.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/support/JdbcConnectionRepositoryConfigSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/support/ProviderConfigurationSupport.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/support/ProviderConfigurationSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/xml/AbstractProviderConfigBeanDefinitionParser.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/xml/AbstractProviderConfigBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/xml/AbstractProviderConfigNamespaceHandler.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/xml/AbstractProviderConfigNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/xml/ApiHelper.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/xml/ApiHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/xml/InMemoryConnectionRepositoryBeanDefinitionParser.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/xml/InMemoryConnectionRepositoryBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/xml/JdbcConnectionRepositoryBeanDefinitionParser.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/xml/JdbcConnectionRepositoryBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/main/java/org/springframework/social/config/xml/SocialNamespaceHandler.java
+++ b/spring-social-config/src/main/java/org/springframework/social/config/xml/SocialNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/test/java/org/springframework/social/config/DummyConnection.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/DummyConnection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/test/java/org/springframework/social/config/Fake.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/Fake.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/test/java/org/springframework/social/config/FakeConnectionFactory.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/FakeConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/test/java/org/springframework/social/config/FakeConnectionSignUp.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/FakeConnectionSignUp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/test/java/org/springframework/social/config/FakeSocialAuthenticationService.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/FakeSocialAuthenticationService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/test/java/org/springframework/social/config/FakeTemplate.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/FakeTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/test/java/org/springframework/social/config/SimpleUserIdSource.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/SimpleUserIdSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/test/java/org/springframework/social/config/annotation/MyAwesomeSocialConfig.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/annotation/MyAwesomeSocialConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/test/java/org/springframework/social/config/annotation/SocialConfigAnnotationTest.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/annotation/SocialConfigAnnotationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/test/java/org/springframework/social/config/xml/FakeConnectionFactoryBeanDefinitionParser.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/xml/FakeConnectionFactoryBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/test/java/org/springframework/social/config/xml/FakeNamespaceHandler.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/xml/FakeNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-config/src/test/java/org/springframework/social/config/xml/SocialConfigNamespaceTest.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/xml/SocialConfigNamespaceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/ApiBinding.java
+++ b/spring-social-core/src/main/java/org/springframework/social/ApiBinding.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/ApiException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/ApiException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/DuplicateStatusException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/DuplicateStatusException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/ExpiredAuthorizationException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/ExpiredAuthorizationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/InsufficientPermissionException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/InsufficientPermissionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/InternalServerErrorException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/InternalServerErrorException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/InvalidAuthorizationException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/InvalidAuthorizationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/MissingAuthorizationException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/MissingAuthorizationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/NotAuthorizedException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/NotAuthorizedException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/OperationNotPermittedException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/OperationNotPermittedException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/RateLimitExceededException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/RateLimitExceededException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/RejectedAuthorizationException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/RejectedAuthorizationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/ResourceNotFoundException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/ResourceNotFoundException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/RevokedAuthorizationException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/RevokedAuthorizationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/ServerDownException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/ServerDownException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/ServerException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/ServerException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/ServerOverloadedException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/ServerOverloadedException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/ServiceProvider.java
+++ b/spring-social-core/src/main/java/org/springframework/social/ServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/SocialException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/SocialException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/UncategorizedApiException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/UncategorizedApiException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/UserIdSource.java
+++ b/spring-social-core/src/main/java/org/springframework/social/UserIdSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/ApiAdapter.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/ApiAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/Connection.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/Connection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionData.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionFactory.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionFactoryLocator.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionFactoryLocator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionKey.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionKey.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionRepositoryException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionRepositoryException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionSignUp.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionSignUp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionValues.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/ConnectionValues.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/DuplicateConnectionException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/DuplicateConnectionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/NoSuchConnectionException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/NoSuchConnectionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/NotConnectedException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/NotConnectedException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/NullApiAdapter.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/NullApiAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/UserProfile.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/UserProfile.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/UserProfileBuilder.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/UserProfileBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/UsersConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/UsersConnectionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/jdbc/JdbcConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/jdbc/JdbcConnectionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/mem/InMemoryConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/mem/InMemoryConnectionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/mem/InMemoryUsersConnectionRepository.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/mem/InMemoryUsersConnectionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/support/AbstractConnection.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/support/AbstractConnection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/support/ConnectionFactoryRegistry.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/support/ConnectionFactoryRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/support/OAuth1Connection.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/support/OAuth1Connection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/support/OAuth1ConnectionFactory.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/support/OAuth1ConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/support/OAuth2Connection.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/support/OAuth2Connection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/connect/support/OAuth2ConnectionFactory.java
+++ b/spring-social-core/src/main/java/org/springframework/social/connect/support/OAuth2ConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/AbstractOAuth1ApiBinding.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/AbstractOAuth1ApiBinding.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/AbstractOAuth1ServiceProvider.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/AbstractOAuth1ServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/AuthorizedRequestToken.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/AuthorizedRequestToken.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/EmptyMultiValueMap.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/EmptyMultiValueMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/GenericOAuth1ConnectionFactory.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/GenericOAuth1ConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/GenericOAuth1ServiceProvider.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/GenericOAuth1ServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuth1Credentials.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuth1Credentials.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuth1Operations.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuth1Operations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuth1Parameters.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuth1Parameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuth1RequestInterceptor.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuth1RequestInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuth1ServiceProvider.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuth1ServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuth1Template.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuth1Template.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuth1Version.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuth1Version.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuthToken.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/OAuthToken.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/ProtectedResourceClientFactory.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/ProtectedResourceClientFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/SigningSupport.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/SigningSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/TreeMultiValueMap.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/TreeMultiValueMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/AbstractOAuth2ApiBinding.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/AbstractOAuth2ApiBinding.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/AbstractOAuth2ServiceProvider.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/AbstractOAuth2ServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/AccessGrant.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/AccessGrant.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/GenericOAuth2ConnectionFactory.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/GenericOAuth2ConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/GenericOAuth2ServiceProvider.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/GenericOAuth2ServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/GrantType.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/GrantType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Operations.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Operations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Parameters.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Parameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2RequestInterceptor.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2RequestInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2ServiceProvider.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2ServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Template.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Template.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2TokenParameterRequestInterceptor.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2TokenParameterRequestInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Version.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/OAuth2Version.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/PreemptiveBasicAuthClientHttpRequestInterceptor.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/PreemptiveBasicAuthClientHttpRequestInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/oauth2/TokenStrategy.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth2/TokenStrategy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/support/BufferingClientHttpResponse.java
+++ b/spring-social-core/src/main/java/org/springframework/social/support/BufferingClientHttpResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/support/ClientHttpRequestFactorySelector.java
+++ b/spring-social-core/src/main/java/org/springframework/social/support/ClientHttpRequestFactorySelector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/support/FormMapHttpMessageConverter.java
+++ b/spring-social-core/src/main/java/org/springframework/social/support/FormMapHttpMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/support/HttpRequestDecorator.java
+++ b/spring-social-core/src/main/java/org/springframework/social/support/HttpRequestDecorator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/support/LoggingErrorHandler.java
+++ b/spring-social-core/src/main/java/org/springframework/social/support/LoggingErrorHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/support/ParameterMap.java
+++ b/spring-social-core/src/main/java/org/springframework/social/support/ParameterMap.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/support/URIBuilder.java
+++ b/spring-social-core/src/main/java/org/springframework/social/support/URIBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/main/java/org/springframework/social/support/URIBuilderException.java
+++ b/spring-social-core/src/main/java/org/springframework/social/support/URIBuilderException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/connect/ConnectionKeyTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/ConnectionKeyTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/connect/FakeApi.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/FakeApi.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/connect/FakeApiAdapter.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/FakeApiAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepositoryPrefixedTableTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepositoryPrefixedTableTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepositoryTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/JdbcUsersConnectionRepositoryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/connect/mem/InMemoryUsersConnectionRepositoryTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/mem/InMemoryUsersConnectionRepositoryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/connect/oauth1/FakeServiceProvider.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/oauth1/FakeServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/connect/oauth1/OAuth1ConnectionTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/oauth1/OAuth1ConnectionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/connect/oauth1/StubOAuth1Operations.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/oauth1/StubOAuth1Operations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/connect/oauth2/FakeServiceProvider.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/oauth2/FakeServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/connect/oauth2/OAuth2ConnectionTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/oauth2/OAuth2ConnectionTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/connect/oauth2/StubOAuth2Operations.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/oauth2/StubOAuth2Operations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/connect/support/ConnectionFactoryRegistryTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/support/ConnectionFactoryRegistryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/oauth1/AbstractOAuth1ApiBindingTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/oauth1/AbstractOAuth1ApiBindingTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/oauth1/MockTimestampGenerator.java
+++ b/spring-social-core/src/test/java/org/springframework/social/oauth1/MockTimestampGenerator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/oauth1/OAuth1RequestInterceptorTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/oauth1/OAuth1RequestInterceptorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/oauth1/OAuth1TemplateTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/oauth1/OAuth1TemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/oauth1/SigningSupportTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/oauth1/SigningSupportTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/oauth2/AbstractOAuth2ApiBindingTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/oauth2/AbstractOAuth2ApiBindingTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/oauth2/OAuth2RequestInterceptorTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/oauth2/OAuth2RequestInterceptorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/oauth2/OAuth2TemplateTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/oauth2/OAuth2TemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/oauth2/OAuth2TokenParameterRequestInterceptorTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/oauth2/OAuth2TokenParameterRequestInterceptorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/support/ClientHttpRequestFactorySelectorTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/support/ClientHttpRequestFactorySelectorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/support/URIBuilderTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/support/URIBuilderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-core/src/test/java/org/springframework/social/util/URIBuilderTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/util/URIBuilderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/AuthenticationNameUserIdSource.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/AuthenticationNameUserIdSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationException.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFailureHandler.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFailureHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationProvider.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationRedirectException.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationRedirectException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationServiceLocator.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationServiceLocator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationServiceRegistry.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationServiceRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationToken.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialAuthenticationToken.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialUser.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialUser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialUserDetails.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialUserDetails.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/SocialUserDetailsService.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SocialUserDetailsService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/SpringSocialConfigurer.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/SpringSocialConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/provider/AbstractSocialAuthenticationService.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/provider/AbstractSocialAuthenticationService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/provider/OAuth1AuthenticationService.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/provider/OAuth1AuthenticationService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/provider/OAuth2AuthenticationService.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/provider/OAuth2AuthenticationService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/main/java/org/springframework/social/security/provider/SocialAuthenticationService.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/provider/SocialAuthenticationService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/test/java/org/springframework/social/security/SocialAuthenticationFilterTest.java
+++ b/spring-social-security/src/test/java/org/springframework/social/security/SocialAuthenticationFilterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/test/java/org/springframework/social/security/SocialAuthenticationProviderTest.java
+++ b/spring-social-security/src/test/java/org/springframework/social/security/SocialAuthenticationProviderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/test/java/org/springframework/social/security/SocialAuthenticationTokenTest.java
+++ b/spring-social-security/src/test/java/org/springframework/social/security/SocialAuthenticationTokenTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/test/java/org/springframework/social/security/provider/OAuth1AuthenticationServiceTest.java
+++ b/spring-social-security/src/test/java/org/springframework/social/security/provider/OAuth1AuthenticationServiceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/test/java/org/springframework/social/security/provider/OAuth2AuthenticationServiceTest.java
+++ b/spring-social-security/src/test/java/org/springframework/social/security/provider/OAuth2AuthenticationServiceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/test/java/org/springframework/social/security/test/ArgMatchers.java
+++ b/spring-social-security/src/test/java/org/springframework/social/security/test/ArgMatchers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/test/java/org/springframework/social/security/test/DummyConnection.java
+++ b/spring-social-security/src/test/java/org/springframework/social/security/test/DummyConnection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/test/java/org/springframework/social/security/test/DummyUserDetails.java
+++ b/spring-social-security/src/test/java/org/springframework/social/security/test/DummyUserDetails.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-security/src/test/java/org/springframework/social/security/test/MockConnectionFactory.java
+++ b/spring-social-security/src/test/java/org/springframework/social/security/test/MockConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-thymeleaf3/src/main/java/org/springframework/social/connect/web/thymeleaf3/ConnectedAttrProcessor.java
+++ b/spring-social-thymeleaf3/src/main/java/org/springframework/social/connect/web/thymeleaf3/ConnectedAttrProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-thymeleaf3/src/main/java/org/springframework/social/connect/web/thymeleaf3/NotConnectedAttrProcessor.java
+++ b/spring-social-thymeleaf3/src/main/java/org/springframework/social/connect/web/thymeleaf3/NotConnectedAttrProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-thymeleaf3/src/main/java/org/springframework/social/connect/web/thymeleaf3/SpringSocialDialect.java
+++ b/spring-social-thymeleaf3/src/main/java/org/springframework/social/connect/web/thymeleaf3/SpringSocialDialect.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ConnectController.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ConnectController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ConnectInterceptor.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ConnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ConnectSupport.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ConnectSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/DisconnectInterceptor.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/DisconnectInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/GenericConnectionStatusView.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/GenericConnectionStatusView.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInAttempt.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInAttempt.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInController.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInInterceptor.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInUtils.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ReconnectFilter.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ReconnectFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/SessionUserIdSource.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/SessionUserIdSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/SignInAdapter.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/SignInAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ThrowableAnalyzer.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ThrowableAnalyzer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/taglib/BaseSocialConnectedTag.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/taglib/BaseSocialConnectedTag.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/taglib/SocialConnectedTag.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/taglib/SocialConnectedTag.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/taglib/SocialNotConnectedTag.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/taglib/SocialNotConnectedTag.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/thymeleaf/ConnectedAttrProcessor.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/thymeleaf/ConnectedAttrProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/thymeleaf/NotConnectedAttrProcessor.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/thymeleaf/NotConnectedAttrProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/thymeleaf/SpringSocialDialect.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/thymeleaf/SpringSocialDialect.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/ConnectControllerTest.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/ConnectControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/ConnectSupportTest.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/ConnectSupportTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/ProviderSignInControllerTest.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/ProviderSignInControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/ReconnectFilterTest.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/ReconnectFilterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/SessionUserIdSourceTest.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/SessionUserIdSourceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubConnectionRepository.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubConnectionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubOAuth1ConnectionFactory.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubOAuth1ConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubOAuth1ServiceProvider.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubOAuth1ServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubOAuth1Template.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubOAuth1Template.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubOAuth2ConnectionFactory.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubOAuth2ConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubOAuth2ServiceProvider.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubOAuth2ServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubOAuth2Template.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubOAuth2Template.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubOAuthTemplateBehavior.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubOAuthTemplateBehavior.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubUsersConnectionRepository.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/test/StubUsersConnectionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/test/TestApi1.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/test/TestApi1.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/test/TestApi2.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/test/TestApi2.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/dist/license.txt
+++ b/src/dist/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 2 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 212 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).