### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -41,5 +41,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -31,7 +31,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).
 

--- a/NOTICE
+++ b/NOTICE
@@ -4,13 +4,13 @@
    ========================================================================
 
    This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+   the Apache Software Foundation (https://www.apache.org).
 
    The end-user documentation included with a redistribution, if any,
    must include the following acknowledgement:
 
      "This product includes software developed by the Spring Framework
-      Project (http://www.springframework.org)."
+      Project (https://www.springframework.org)."
 
    Alternatively, this acknowledgement may appear in the software itself,
    if and wherever such third-party acknowledgements normally appear.

--- a/README.md
+++ b/README.md
@@ -42,19 +42,19 @@ See [downloading Spring artifacts] for Maven repository information. Unable to u
 <repository>
     <id>spring-repo</id>
     <name>Spring Repository</name>
-    <url>http://repo.spring.io/release</url>
+    <url>https://repo.spring.io/release</url>
 </repository>   
     
 <repository>
     <id>spring-milestone</id>
     <name>Spring Milestone Repository</name>
-    <url>http://repo.spring.io/milestone</url>
+    <url>https://repo.spring.io/milestone</url>
 </repository>
 
 <repository>
     <id>spring-snapshot</id>
     <name>Spring Snapshot Repository</name>
-    <url>http://repo.spring.io/snapshot</url>
+    <url>https://repo.spring.io/snapshot</url>
 </repository>
 ```
 
@@ -153,30 +153,30 @@ $ ./gradlew idea
 [Spring Social] is released under version 2.0 of the [Apache License].
 
 
-[Spring Social]: http://projects.spring.io/spring-social
-[Spring Framework]: http://projects.spring.io/spring-framework
+[Spring Social]: https://projects.spring.io/spring-social
+[Spring Framework]: https://projects.spring.io/spring-framework
 [downloading Spring artifacts]: https://github.com/spring-projects/spring-framework/wiki/Downloading-Spring-artifacts
 [building a distribution with dependencies]: https://github.com/spring-projects/spring-framework/wiki/Building-a-distribution-with-dependencies
 [twitter-gh]: https://github.com/spring-projects/spring-social-twitter
-[twitter-ref]: http://docs.spring.io/spring-social-twitter/docs/current/reference/htmlsingle/
-[twitter-api]: http://docs.spring.io/spring-social-twitter/docs/current/apidocs/
+[twitter-ref]: https://docs.spring.io/spring-social-twitter/docs/current/reference/htmlsingle/
+[twitter-api]: https://docs.spring.io/spring-social-twitter/docs/current/apidocs/
 [facebook-gh]: https://github.com/spring-projects/spring-social-facebook
-[facebook-ref]: http://docs.spring.io/spring-social-facebook/docs/current/reference/htmlsingle/
-[facebook-api]: http://docs.spring.io/spring-social-facebook/docs/current/apidocs/
+[facebook-ref]: https://docs.spring.io/spring-social-facebook/docs/current/reference/htmlsingle/
+[facebook-api]: https://docs.spring.io/spring-social-facebook/docs/current/apidocs/
 [linkedin-gh]: https://github.com/spring-projects/spring-social-linkedin
-[linkedin-ref]: http://docs.spring.io/spring-social-linkedin/docs/1.0.x/reference/htmlsingle/
-[linkedin-api]: http://docs.spring.io/spring-social-linkedin/docs/1.0.x/api/
+[linkedin-ref]: https://docs.spring.io/spring-social-linkedin/docs/1.0.x/reference/htmlsingle/
+[linkedin-api]: https://docs.spring.io/spring-social-linkedin/docs/1.0.x/api/
 [tripit-gh]: https://github.com/spring-projects/spring-social-tripit
 [github-gh]: https://github.com/spring-projects/spring-social-github
-[Javadoc]: http://docs.spring.io/spring-social/docs/current/apidocs/
-[reference docs]: http://docs.spring.io/spring-social/docs/current-SNAPSHOT/reference/htmlsingle/
+[Javadoc]: https://docs.spring.io/spring-social/docs/current/apidocs/
+[reference docs]: https://docs.spring.io/spring-social/docs/current-SNAPSHOT/reference/htmlsingle/
 [samples repository]: https://github.com/spring-projects/spring-social-samples
 [Quick Start]: https://github.com/spring-projects/spring-social/wiki/Quick-Start
-[Spring Social JIRA]: http://jira.springsource.org/browse/SOCIAL
+[Spring Social JIRA]: https://jira.springsource.org/browse/SOCIAL
 [GitHub issues]: https://github.com/spring-projects/spring-social/issues
 [the lifecycle of an issue]: https://github.com/spring-projects/spring-framework/wiki/The-Lifecycle-of-an-Issue
-[Gradle]: http://gradle.org
+[Gradle]: https://gradle.org
 [sts]: https://spring.io/tools
-[Pull requests]: http://help.github.com/send-pull-requests
+[Pull requests]: https://help.github.com/send-pull-requests
 [contributor guidelines]: https://github.com/spring-projects/spring-framework/blob/master/CONTRIBUTING.md
 [Apache License]: http://www.apache.org/licenses/LICENSE-2.0

--- a/docs/manual/src/asciidoc/index.adoc
+++ b/docs/manual/src/asciidoc/index.adoc
@@ -147,7 +147,7 @@ repository to your build in order to resolve the artifacts:
 ----
 repositories {
   mavenLocal()
-  maven { url 'http://maven.springframework.org/milestone' }
+  maven { url 'https://maven.springframework.org/milestone' }
   mavenCentral()
 }
 ----
@@ -160,7 +160,7 @@ Similarly, if you are trying out the latest nightly build version (e.g.
 ----
 repositories {
   mavenLocal()
-  maven { url 'http://maven.springframework.org/snapshot' }
+  maven { url 'https://maven.springframework.org/snapshot' }
   mavenCentral()
 }
 ----
@@ -240,7 +240,7 @@ repository to your build in order to resolve the artifacts:
 <repository>
     <id>org.springframework.maven.milestone</id>
     <name>Spring Maven Milestone Repository</name>
-        <url>http://repo.spring.io/milestone</url>
+        <url>https://repo.spring.io/milestone</url>
 </repository>
 ----
 
@@ -253,7 +253,7 @@ Similarly, if you are trying out the latest nightly build version (e.g.
 <repository>
     <id>org.springframework.maven.snapshot</id>
     <name>Spring Maven Snapshot Repository</name>
-        <url>http://repo.spring.io/snapshot</url>
+        <url>https://repo.spring.io/snapshot</url>
 </repository>
 ----
 
@@ -269,9 +269,9 @@ providers. These client modules are listed in <<table_clientModules>>.
 [options="header"]
 |=======================================================================
 |Name |Maven group ID |Maven artifact ID
-|http://docs.spring.io/spring-social-facebook/site/docs/1.1.0.RC1/reference/htmlsingle/[Spring Social Facebook] |org.springframework.social |spring-social-facebook
-|http://docs.spring.io/spring-social-twitter/site/docs/1.1.0.RC1/reference/htmlsingle/[Spring Social Twitter] |org.springframework.social |spring-social-twitter
-|http://docs.spring.io/spring-social-linkedin/site/docs/1.1.0.RC1/reference/htmlsingle/[Spring Social LinkedIn] |org.springframework.social |spring-social-linkedin
+|https://docs.spring.io/spring-social-facebook/site/docs/1.1.0.RC1/reference/htmlsingle/[Spring Social Facebook] |org.springframework.social |spring-social-facebook
+|https://docs.spring.io/spring-social-twitter/site/docs/1.1.0.RC1/reference/htmlsingle/[Spring Social Twitter] |org.springframework.social |spring-social-twitter
+|https://docs.spring.io/spring-social-linkedin/site/docs/1.1.0.RC1/reference/htmlsingle/[Spring Social LinkedIn] |org.springframework.social |spring-social-linkedin
 |Spring Social GitHub |org.springframework.social |spring-social-github
 |Spring Social TripIt |org.springframework.social |spring-social-tripit
 |=======================================================================
@@ -322,7 +322,7 @@ The Spring Social web support requires Java Servlet 2.5 or greater
 
 ===== Spring Framework
 Spring Social depends on `RestTemplate` provided by the core
-http://www.springsource.org/documentation[Spring Framework] in the
+https://www.springsource.org/documentation[Spring Framework] in the
 spring-web module. It requires Spring Framework version 3.1 or above, although
 Spring Framework 4.0 is recommended.
 
@@ -345,7 +345,7 @@ nothing for you to do because the crypto library comes included.
 
 ===== Apache HttpComponents
 Spring Social has an optional dependency on
-http://hc.apache.org/httpcomponents-client-ga[Apache HttpComponents]. If
+https://hc.apache.org/httpcomponents-client-ga[Apache HttpComponents]. If
 the HttpComponents HttpClient library is present, it will use it as the
 HTTP client (which is generally recommended). Otherwise, it will fall
 back on standard J2SE facilities.
@@ -364,7 +364,7 @@ Even thought HttpComponents is an optional dependency, we strongly recommend it 
 
 ===== Jackson JSON Processor
 Spring Social's provider API bindings rely on the
-http://jackson.codehaus.org/[Jackson JSON Processor] to map JSON
+https://jackson.codehaus.org/[Jackson JSON Processor] to map JSON
 responses to Java objects. Each binding, such as Facebook or Twitter,
 transitively depends on Jackson {jacksonVersion}, so there's nothing special to do
 to add Jackson to your project's Maven or Gradle build.
@@ -496,9 +496,9 @@ user with screen name 'jbauer'.
 '14710604' is @jbauer's Twitter-assigned user id that never changes.
 2.  `Connection#getDisplayName()` would return '@jbauer'.
 3.  `Connection#getProfileUrl()` would return
-'http://twitter.com/jbauer'.
+'https://twitter.com/jbauer'.
 4.  `Connection#getImageUrl()` would return
-'http://a0.twimg.com/profile_images/105951287/IMG_5863_2_normal.jpg'.
+'https://a0.twimg.com/profile_images/105951287/IMG_5863_2_normal.jpg'.
 5.  `Connection#sync()` would synchronize the state of the connection with
 @jbauer's profile.
 6.  `Connection#test()` would return `true` indicating the authorization
@@ -1307,7 +1307,7 @@ In contrast, Facebook is an OAuth 2 provider, so its authorization URL takes a s
 https://graph.facebook.com/oauth/authorize?client_id={clientId}&redirect_uri={redirectUri}
 ------------------------------------------------------------------------------------------
 
-Thus, if the application's Facebook client ID is "0b754" and it's redirect URI is "http://www.mycoolapp.com/connect/facebook", then the browser would be redirected to https://graph.facebook.com/oauth/authorize?client_id=0b754&redirect_uri=http://www.mycoolapp.com/connect/facebook and Facebook would display the following authorization page to the user:
+Thus, if the application's Facebook client ID is "0b754" and it's redirect URI is "https://www.hugedomains.com/domain_profile.cfm?d=mycoolapp&e=com", then the browser would be redirected to https://graph.facebook.com/oauth/authorize?client_id=0b754&redirect_uri=https://www.hugedomains.com/domain_profile.cfm?d=mycoolapp&e=com and Facebook would display the following authorization page to the user:
 
 image:resources/images/facebook-authorize-basic.png[image]
 
@@ -1364,7 +1364,7 @@ When asking for "publish_stream,offline_access" authorization, the user will be 
 image:resources/images/facebook-authorize-scoped.png[image]
 
 Scope values are provider-specific, so check with the service provider's documentation for the available scopes. 
-Facebook scopes are documented at http://developers.facebook.com/docs/authentication/permissions[].
+Facebook scopes are documented at https://developers.facebook.com/docs/authentication/permissions[].
 
 [[]]
 ==== Responding to the authorization callback
@@ -1381,7 +1381,7 @@ The last thing that `ConnectController` does is to hand off the access token to 
 ==== Disconnecting
 To delete a connection via `ConnectController`, submit a DELETE request to "/connect/\{provider}".
 
-In order to support this through a form in a web browser, you'll need to have Spring's http://docs.spring.io/spring/docs/3.0.x/javadoc-api/org/springframework/web/filter/HiddenHttpMethodFilter.html[HiddenHttpMethodFilter] configured in your application's web.xml. 
+In order to support this through a form in a web browser, you'll need to have Spring's https://docs.spring.io/spring/docs/3.0.x/javadoc-api/org/springframework/web/filter/HiddenHttpMethodFilter.html[HiddenHttpMethodFilter] configured in your application's web.xml. 
 Then you can provide a disconnect button via a form like this:
 
 ```html

--- a/docs/manual/src/asciidoc/resources/xsl/html-custom.xsl
+++ b/docs/manual/src/asciidoc/resources/xsl/html-custom.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				exclude-result-prefixes="xslthl"
 				version='1.0'>
 

--- a/docs/manual/src/asciidoc/resources/xsl/html-single-custom.xsl
+++ b/docs/manual/src/asciidoc/resources/xsl/html-single-custom.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 

--- a/docs/manual/src/asciidoc/resources/xsl/pdf-custom.xsl
+++ b/docs/manual/src/asciidoc/resources/xsl/pdf-custom.xsl
@@ -21,7 +21,7 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
     <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>

--- a/spring-social-config/src/test/java/org/springframework/social/config/DummyConnection.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/DummyConnection.java
@@ -47,11 +47,11 @@ public class DummyConnection<T> implements Connection<T> {
 	}
 
 	public String getProfileUrl() {
-		return "http://www.example.com/" + _key.getProviderUserId();
+		return "https://www.example.com/" + _key.getProviderUserId();
 	}
 
 	public String getImageUrl() {
-		return "http://www.example.com/img/" + _key.getProviderUserId() + ".jpg";
+		return "https://www.example.com/img/" + _key.getProviderUserId() + ".jpg";
 	}
 
 	public void sync() {

--- a/spring-social-config/src/test/java/org/springframework/social/config/FakeConnectionFactory.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/FakeConnectionFactory.java
@@ -41,7 +41,7 @@ public class FakeConnectionFactory extends OAuth2ConnectionFactory<Fake> {
 	
 	public static final class FakeServiceProvider extends AbstractOAuth2ServiceProvider<Fake> {
 		public FakeServiceProvider(String appId, String appSecret) {
-			super(new OAuth2Template(appId, appSecret, "http://fake.com/auth", "http://fake.com/token"));
+			super(new OAuth2Template(appId, appSecret, "https://fake.com/auth", "https://fake.com/token"));
 		}
 		
 		@Override

--- a/spring-social-config/src/test/java/org/springframework/social/config/annotation/SocialConfigAnnotationTest.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/annotation/SocialConfigAnnotationTest.java
@@ -95,7 +95,7 @@ public class SocialConfigAnnotationTest {
 	private void testConnectionRepository(ConnectionFactoryLocator cfl, ConnectionRepository connectionRepository) {
 		assertNull(connectionRepository.findPrimaryConnection(Fake.class));
 		ConnectionFactory<Fake> fakeCF = cfl.getConnectionFactory(Fake.class);
-		Connection<Fake> connection = fakeCF.createConnection(new ConnectionData("fake", "bob", "Bob McBob", "http://www.twitter.com/mcbob", null, "someToken", "someSecret", null, null));
+		Connection<Fake> connection = fakeCF.createConnection(new ConnectionData("fake", "bob", "Bob McBob", "https://www.twitter.com/mcbob", null, "someToken", "someSecret", null, null));
 		connectionRepository.addConnection(connection);
 		assertNotNull(connectionRepository.findPrimaryConnection(Fake.class));
 		assertTrue(context.getBean(Fake.class).isAuthorized());

--- a/spring-social-config/src/test/java/org/springframework/social/config/xml/SocialConfigNamespaceTest.java
+++ b/spring-social-config/src/test/java/org/springframework/social/config/xml/SocialConfigNamespaceTest.java
@@ -101,7 +101,7 @@ public class SocialConfigNamespaceTest {
 	private void testConnectionRepository(ConnectionFactoryLocator cfl, ConnectionRepository connectionRepository) {
 		assertNull(connectionRepository.findPrimaryConnection(Fake.class));
 		ConnectionFactory<Fake> fakeCF = cfl.getConnectionFactory(Fake.class);
-		Connection<Fake> connection = fakeCF.createConnection(new ConnectionData("fake", "bob", "Bob McBob", "http://www.twitter.com/mcbob", null, "someToken", "someSecret", null, null));
+		Connection<Fake> connection = fakeCF.createConnection(new ConnectionData("fake", "bob", "Bob McBob", "https://www.twitter.com/mcbob", null, "someToken", "someSecret", null, null));
 		connectionRepository.addConnection(connection);
 		assertNotNull(connectionRepository.findPrimaryConnection(Fake.class));
 		assertTrue(context.getBean(Fake.class).isAuthorized());

--- a/spring-social-core/src/main/java/org/springframework/social/oauth1/SigningSupport.java
+++ b/spring-social-core/src/main/java/org/springframework/social/oauth1/SigningSupport.java
@@ -130,7 +130,7 @@ class SigningSupport {
 	// internal helpers
 	
 	private String normalizeParameters(MultiValueMap<String, String> collectedParameters) {
-		// Normalizes the collected parameters for baseString calculation, per http://tools.ietf.org/html/rfc5849#section-3.4.1.3.2
+		// Normalizes the collected parameters for baseString calculation, per https://tools.ietf.org/html/rfc5849#section-3.4.1.3.2
 		MultiValueMap<String, String> sortedEncodedParameters = new TreeMultiValueMap<String, String>();
 		for (Iterator<Entry<String, List<String>>> entryIt = collectedParameters.entrySet().iterator(); entryIt.hasNext();) {
 			Entry<String, List<String>> entry = entryIt.next();
@@ -223,7 +223,7 @@ class SigningSupport {
 
 	private String getBaseStringUri(URI uri) {
 		try {
-			// see: http://tools.ietf.org/html/rfc5849#section-3.4.1.2
+			// see: https://tools.ietf.org/html/rfc5849#section-3.4.1.2
 			return new URI(uri.getScheme(), null, uri.getHost(), getPort(uri), uri.getPath(), null, null).toString();
 		} catch (URISyntaxException e) {
 			throw new IllegalArgumentException(e);
@@ -279,7 +279,7 @@ class SigningSupport {
 	
 	private static String oauthEncode(String param) {
 		try {
-			// See http://tools.ietf.org/html/rfc5849#section-3.6
+			// See https://tools.ietf.org/html/rfc5849#section-3.6
 			byte[] bytes = encode(param.getBytes(UTF8_CHARSET_NAME), UNRESERVED);
 			return new String(bytes, "US-ASCII");
 		} catch (Exception shouldntHappen) {

--- a/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/AbstractUsersConnectionRepositoryTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/jdbc/AbstractUsersConnectionRepositoryTest.java
@@ -47,7 +47,7 @@ public abstract class AbstractUsersConnectionRepositoryTest {
 	protected static final String FACEBOOK_CONNECTION_3_PROVIDER_USER_ID = "11";
 	
 	protected static final ConnectionData TWITTER_DATA =
-			new ConnectionData("twitter", TWITTER_CONNECTION_1_PROVIDER_USER_ID, "@kdonald", "http://twitter.com/kdonald", "http://twitter.com/kdonald/picture", "123456789", "987654321", "refresh_token", System.currentTimeMillis() + 3600000);
+			new ConnectionData("twitter", TWITTER_CONNECTION_1_PROVIDER_USER_ID, "@kdonald", "https://twitter.com/kdonald", "https://twitter.com/kdonald/picture", "123456789", "987654321", "refresh_token", System.currentTimeMillis() + 3600000);
 	protected static final ConnectionData FACEBOOK_DATA_1 =
 			new ConnectionData("facebook", FACEBOOK_CONNECTION_1_PROVIDER_USER_ID, null, null, null, "234567890", null, "345678901", System.currentTimeMillis() + 3600000);
 	protected static final ConnectionData FACEBOOK_DATA_2 =
@@ -340,12 +340,12 @@ public abstract class AbstractUsersConnectionRepositoryTest {
 	public void updateConnectionProfileFields() {
 		insertTwitterConnection();
 		Connection<TestTwitterApi> twitter = getConnectionRepository().getPrimaryConnection(TestTwitterApi.class);
-		assertEquals("http://twitter.com/kdonald/picture", twitter.getImageUrl());
+		assertEquals("https://twitter.com/kdonald/picture", twitter.getImageUrl());
 		twitter.sync();
-		assertEquals("http://twitter.com/kdonald/a_new_picture", twitter.getImageUrl());
+		assertEquals("https://twitter.com/kdonald/a_new_picture", twitter.getImageUrl());
 		getConnectionRepository().updateConnection(twitter);
 		Connection<TestTwitterApi> twitter2 = getConnectionRepository().getPrimaryConnection(TestTwitterApi.class);
-		assertEquals("http://twitter.com/kdonald/a_new_picture", twitter2.getImageUrl());
+		assertEquals("https://twitter.com/kdonald/a_new_picture", twitter2.getImageUrl());
 	}
 
 	@Test
@@ -383,8 +383,8 @@ public abstract class AbstractUsersConnectionRepositoryTest {
 		assertEquals("facebook", connection.getKey().getProviderId());
 		assertEquals(FACEBOOK_CONNECTION_1_PROVIDER_USER_ID, connection.getKey().getProviderUserId());
 		assertEquals("Keith Donald", connection.getDisplayName());
-		assertEquals("http://facebook.com/keith.donald", connection.getProfileUrl());
-		assertEquals("http://facebook.com/keith.donald/picture", connection.getImageUrl());
+		assertEquals("https://facebook.com/keith.donald", connection.getProfileUrl());
+		assertEquals("https://facebook.com/keith.donald/picture", connection.getImageUrl());
 		assertTrue(connection.test());
 		TestFacebookApi api = connection.getApi();
 		assertNotNull(api);
@@ -396,13 +396,13 @@ public abstract class AbstractUsersConnectionRepositoryTest {
 	private void assertTwitterConnection(Connection<TestTwitterApi> twitter) {
 		assertEquals(new ConnectionKey("twitter", TWITTER_CONNECTION_1_PROVIDER_USER_ID), twitter.getKey());
 		assertEquals("@kdonald", twitter.getDisplayName());
-		assertEquals("http://twitter.com/kdonald", twitter.getProfileUrl());
-		assertEquals("http://twitter.com/kdonald/picture", twitter.getImageUrl());
+		assertEquals("https://twitter.com/kdonald", twitter.getProfileUrl());
+		assertEquals("https://twitter.com/kdonald/picture", twitter.getImageUrl());
 		TestTwitterApi twitterApi = twitter.getApi();
 		assertEquals("123456789", twitterApi.getAccessToken());		
 		assertEquals("987654321", twitterApi.getSecret());
 		twitter.sync();
-		assertEquals("http://twitter.com/kdonald/a_new_picture", twitter.getImageUrl());
+		assertEquals("https://twitter.com/kdonald/a_new_picture", twitter.getImageUrl());
 	}
 
 	private void assertFacebookConnection(Connection<TestFacebookApi> facebook) {
@@ -414,8 +414,8 @@ public abstract class AbstractUsersConnectionRepositoryTest {
 		assertEquals("234567890", facebookApi.getAccessToken());
 		facebook.sync();
 		assertEquals("Keith Donald", facebook.getDisplayName());
-		assertEquals("http://facebook.com/keith.donald", facebook.getProfileUrl());
-		assertEquals("http://facebook.com/keith.donald/picture", facebook.getImageUrl());		
+		assertEquals("https://facebook.com/keith.donald", facebook.getProfileUrl());
+		assertEquals("https://facebook.com/keith.donald/picture", facebook.getImageUrl());		
 	}
 
 	protected static class TestFacebookServiceProvider implements OAuth2ServiceProvider<TestFacebookApi> {
@@ -490,9 +490,9 @@ public abstract class AbstractUsersConnectionRepositoryTest {
 			
 			private final String name = "Keith Donald";
 			
-			private final String profileUrl = "http://facebook.com/keith.donald";
+			private final String profileUrl = "https://facebook.com/keith.donald";
 			
-			private final String profilePictureUrl = "http://facebook.com/keith.donald/picture";
+			private final String profilePictureUrl = "https://facebook.com/keith.donald/picture";
 			
 			@Override
 			public boolean test(TestFacebookApi api) {
@@ -564,9 +564,9 @@ public abstract class AbstractUsersConnectionRepositoryTest {
 			
 			private final String name = "@kdonald";
 			
-			private final String profileUrl = "http://twitter.com/kdonald";
+			private final String profileUrl = "https://twitter.com/kdonald";
 			
-			private final String profilePictureUrl = "http://twitter.com/kdonald/a_new_picture";
+			private final String profilePictureUrl = "https://twitter.com/kdonald/a_new_picture";
 			
 			@Override
 			public boolean test(TestTwitterApi api) {

--- a/spring-social-core/src/test/java/org/springframework/social/connect/oauth1/StubOAuth1Operations.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/oauth1/StubOAuth1Operations.java
@@ -33,11 +33,11 @@ class StubOAuth1Operations implements OAuth1Operations {
 	}
 
 	public String buildAuthorizeUrl(String requestToken, OAuth1Parameters parameters) {
-		return "http://springsource.org/oauth/authorize?request_token=" + requestToken;
+		return "https://springsource.org/oauth/authorize?request_token=" + requestToken;
 	}
 
 	public String buildAuthenticateUrl(String requestToken, OAuth1Parameters parameters) {
-		return "http://springsource.org/oauth/authenticate?request_token=" + requestToken;
+		return "https://springsource.org/oauth/authenticate?request_token=" + requestToken;
 	}
 
 	public OAuthToken exchangeForAccessToken(AuthorizedRequestToken requestToken, MultiValueMap<String, String> additionalParameters) {

--- a/spring-social-core/src/test/java/org/springframework/social/connect/oauth2/StubOAuth2Operations.java
+++ b/spring-social-core/src/test/java/org/springframework/social/connect/oauth2/StubOAuth2Operations.java
@@ -24,7 +24,7 @@ import org.springframework.util.MultiValueMap;
 class StubOAuth2Operations implements OAuth2Operations {
 
 	public String buildAuthorizeUrl(GrantType grantType, OAuth2Parameters parameters) {
-		return "http://springsource.org/oauth/authorize?scope=" + parameters.getScope();
+		return "https://springsource.org/oauth/authorize?scope=" + parameters.getScope();
 	}
 	
 	public String buildAuthenticateUrl(GrantType grantType, OAuth2Parameters parameters) {
@@ -32,7 +32,7 @@ class StubOAuth2Operations implements OAuth2Operations {
 	}
 
 	public String buildAuthorizeUrl(OAuth2Parameters parameters) {
-		return "http://springsource.org/oauth/authorize?scope=" + parameters.getScope();
+		return "https://springsource.org/oauth/authorize?scope=" + parameters.getScope();
 	}
 	
 	public String buildAuthenticateUrl(OAuth2Parameters parameters) {

--- a/spring-social-core/src/test/java/org/springframework/social/oauth1/OAuth1TemplateTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/oauth1/OAuth1TemplateTest.java
@@ -61,7 +61,7 @@ public class OAuth1TemplateTest {
 	@Test
 	public void buildAuthorizeUrl() {
 		OAuth1Parameters parameters = new OAuth1Parameters(null);
-		parameters.setCallbackUrl("http://www.someclient.com/oauth/callback");
+		parameters.setCallbackUrl("https://www.someclient.com/oauth/callback");
 		assertEquals(AUTHORIZE_URL + "?oauth_token=request_token",
 				oauth10a.buildAuthorizeUrl("request_token", OAuth1Parameters.NONE));
 		assertEquals(AUTHORIZE_URL + "?oauth_token=request_token&oauth_callback=http%3A%2F%2Fwww.someclient.com%2Foauth%2Fcallback",
@@ -71,7 +71,7 @@ public class OAuth1TemplateTest {
 	@Test
 	public void buildAuthorizeUrl_customAuthorizeParameters() {
 		OAuth1Parameters parameters = new OAuth1Parameters(null);
-		parameters.setCallbackUrl("http://www.someclient.com/oauth/callback");
+		parameters.setCallbackUrl("https://www.someclient.com/oauth/callback");
 		assertEquals(AUTHORIZE_URL + "?oauth_token=request_token&oauth_callback=http%3A%2F%2Fwww.someclient.com%2Foauth%2Fcallback&custom_parameter=custom_parameter_value",
 				customOauth10.buildAuthorizeUrl("request_token", parameters));
 	}
@@ -94,7 +94,7 @@ public class OAuth1TemplateTest {
 				.andExpect(headerContains("Authorization", "oauth_timestamp=\""))
 				.andRespond(withSuccess(new ClassPathResource("requestToken.formencoded", getClass()), MediaType.APPLICATION_FORM_URLENCODED));
 
-		OAuthToken requestToken = oauth10a.fetchRequestToken("http://www.someclient.com/oauth/callback", null);
+		OAuthToken requestToken = oauth10a.fetchRequestToken("https://www.someclient.com/oauth/callback", null);
 		assertEquals("1234567890", requestToken.getValue());
 		assertEquals("abcdefghijklmnop", requestToken.getSecret());
 	}
@@ -114,7 +114,7 @@ public class OAuth1TemplateTest {
 				.andExpect(headerContains("Authorization", "oauth_timestamp=\""))
 				.andRespond(withSuccess(new ClassPathResource("requestToken.formencoded", getClass()), MediaType.APPLICATION_FORM_URLENCODED));
 
-		OAuthToken requestToken = oauth10.fetchRequestToken("http://www.someclient.com/oauth/callback", null);
+		OAuthToken requestToken = oauth10.fetchRequestToken("https://www.someclient.com/oauth/callback", null);
 		assertEquals("1234567890", requestToken.getValue());
 		assertEquals("abcdefghijklmnop", requestToken.getSecret());
 	}

--- a/spring-social-core/src/test/java/org/springframework/social/oauth1/SigningSupportTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/oauth1/SigningSupportTest.java
@@ -46,7 +46,7 @@ public class SigningSupportTest {
 		additionalParameters.add("a3", "a"); // query parameter
 		additionalParameters.add("c@", ""); // query parameter
 		additionalParameters.add("a2", "r b"); // query parameter
-		String authorizationHeader = signingUtils.buildAuthorizationHeaderValue(HttpMethod.POST, new URI("http://example.com/request"), oauthParameters, additionalParameters, "consumer_secret", "token_secret");
+		String authorizationHeader = signingUtils.buildAuthorizationHeaderValue(HttpMethod.POST, new URI("https://example.com/request"), oauthParameters, additionalParameters, "consumer_secret", "token_secret");
 		assertAuthorizationHeader(authorizationHeader, "qz6HT3AG1Z9J%2BP99O4HeMtClGeY%3D");
 	}
 
@@ -54,7 +54,7 @@ public class SigningSupportTest {
 	public void buildAuthorizationHeaderValue_Request() throws Exception {
 		SigningSupport signingUtils = new SigningSupport();
 		signingUtils.setTimestampGenerator(new MockTimestampGenerator(123456789, 987654321));
-		URI uri = URIBuilder.fromUri("http://example.com/request").queryParam("b5", "=%3D").queryParam("a3", "a").queryParam("c@", "")
+		URI uri = URIBuilder.fromUri("https://example.com/request").queryParam("b5", "=%3D").queryParam("a3", "a").queryParam("c@", "")
 			.queryParam("a2", "r b").build();
 		HttpRequest request = new SimpleClientHttpRequestFactory().createRequest(uri, HttpMethod.POST);
 		request.getHeaders().setContentType(MediaType.APPLICATION_FORM_URLENCODED);
@@ -66,7 +66,7 @@ public class SigningSupportTest {
 	public void buildAuthorizationHeaderValue_oauthEncodedSecrets() throws Exception {
 		SigningSupport signingUtils = new SigningSupport();
 		signingUtils.setTimestampGenerator(new MockTimestampGenerator(123456789, 987654321));
-		URI uri = URIBuilder.fromUri("http://example.com/request").queryParam("b5", "=%3D").queryParam("a3", "a").queryParam("c@", "")
+		URI uri = URIBuilder.fromUri("https://example.com/request").queryParam("b5", "=%3D").queryParam("a3", "a").queryParam("c@", "")
 			.queryParam("a2", "r b").build();
 		HttpRequest request = new SimpleClientHttpRequestFactory().createRequest(uri, HttpMethod.POST);
 		request.getHeaders().setContentType(MediaType.APPLICATION_FORM_URLENCODED);
@@ -76,7 +76,7 @@ public class SigningSupportTest {
 
 	/*
 	 * Tests the buildBaseString() method using the example given in the OAuth 1 spec
-	 * at http://tools.ietf.org/html/rfc5849#section-3.4.1 as the test data.
+	 * at https://tools.ietf.org/html/rfc5849#section-3.4.1 as the test data.
 	 */
 	@Test
 	public void buildBaseString_specificationExample() {
@@ -92,7 +92,7 @@ public class SigningSupportTest {
 		collectedParameters.add("c2", "");
 		collectedParameters.add("a3", "2 q");
 		collectedParameters.setAll(oauthParameters);
-		String baseString = signingUtils.buildBaseString(HttpMethod.POST, "http://example.com/request", collectedParameters);
+		String baseString = signingUtils.buildBaseString(HttpMethod.POST, "https://example.com/request", collectedParameters);
 		
 		String[] baseStringParts = baseString.split("&");
 		assertEquals(3, baseStringParts.length);
@@ -116,7 +116,7 @@ public class SigningSupportTest {
 	}
 	
 	/*
-	 * Tests the buildBaseString() method using the example given at http://dev.twitter.com/pages/auth#signing-requests
+	 * Tests the buildBaseString() method using the example given at https://dev.twitter.com/pages/auth#signing-requests
 	 * as the test data.
 	 */
 	@Test

--- a/spring-social-core/src/test/java/org/springframework/social/oauth2/OAuth2TemplateTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/oauth2/OAuth2TemplateTest.java
@@ -51,7 +51,7 @@ public class OAuth2TemplateTest {
 	@Test
 	public void buildAuthorizeUrl_codeResponseType() {
 		OAuth2Parameters parameters = new OAuth2Parameters();
-		parameters.setRedirectUri("http://www.someclient.com/connect/foo");
+		parameters.setRedirectUri("https://www.someclient.com/connect/foo");
 		parameters.setScope("read,write");
 		String expected = AUTHORIZE_URL + "?client_id=client_id&response_type=code&redirect_uri=http%3A%2F%2Fwww.someclient.com%2Fconnect%2Ffoo&scope=read%2Cwrite";
 		String actual = oAuth2Template.buildAuthorizeUrl(parameters);
@@ -61,7 +61,7 @@ public class OAuth2TemplateTest {
 	@Test
 	public void buildAuthorizeUrl_tokenResponseType() {
 		OAuth2Parameters parameters = new OAuth2Parameters();
-		parameters.setRedirectUri("http://www.someclient.com/connect/foo");
+		parameters.setRedirectUri("https://www.someclient.com/connect/foo");
 		parameters.setScope("read,write");
 		String expected = AUTHORIZE_URL + "?client_id=client_id&response_type=token&redirect_uri=http%3A%2F%2Fwww.someclient.com%2Fconnect%2Ffoo&scope=read%2Cwrite";
 		String actual = oAuth2Template.buildAuthorizeUrl(GrantType.IMPLICIT_GRANT, parameters);
@@ -71,7 +71,7 @@ public class OAuth2TemplateTest {
 	@Test
 	public void buildAuthorizeUrl_noScopeInParameters() {
 		OAuth2Parameters parameters = new OAuth2Parameters();
-		parameters.setRedirectUri("http://www.someclient.com/connect/foo");
+		parameters.setRedirectUri("https://www.someclient.com/connect/foo");
 		String expected = AUTHORIZE_URL + "?client_id=client_id&response_type=code&redirect_uri=http%3A%2F%2Fwww.someclient.com%2Fconnect%2Ffoo";
 		String actual = oAuth2Template.buildAuthorizeUrl(parameters);
 		assertEquals(expected, actual);
@@ -80,7 +80,7 @@ public class OAuth2TemplateTest {
 	@Test
 	public void buildAuthorizeUrl_additionalParameters() {
 		OAuth2Parameters parameters = new OAuth2Parameters();
-		parameters.setRedirectUri("http://www.someclient.com/connect/foo");
+		parameters.setRedirectUri("https://www.someclient.com/connect/foo");
 		parameters.setScope("read,write");
 		parameters.add("display", "touch");
 		parameters.add("anotherparam", "somevalue1");
@@ -329,7 +329,7 @@ public class OAuth2TemplateTest {
 			responseActions.andExpect(header("Authorization", expectedAuthorizationHeader));
 		}
 		responseActions.andRespond(withSuccess(new ClassPathResource(responseFile, getClass()), MediaType.APPLICATION_JSON));
-		return oauthTemplate.exchangeForAccess("code", "http://www.someclient.com/callback", null);
+		return oauthTemplate.exchangeForAccess("code", "https://www.someclient.com/callback", null);
 	}
 	
 	private AccessGrant passwordGrant_paramBasedClientAuth(String responseFile) {

--- a/spring-social-core/src/test/java/org/springframework/social/util/URIBuilderTest.java
+++ b/spring-social-core/src/test/java/org/springframework/social/util/URIBuilderTest.java
@@ -26,63 +26,63 @@ public class URIBuilderTest {
 	
 	@Test
 	public void buildSimpleURI() {
-		URI uri = URIBuilder.fromUri("http://example.com").build();
-		assertEquals("http://example.com", uri.toString());		
+		URI uri = URIBuilder.fromUri("https://example.com").build();
+		assertEquals("https://example.com", uri.toString());		
 	}
 	
 	@Test
 	public void buildURIWithExistingParameters() {
-		URI uri = URIBuilder.fromUri("http://example.com?foo=bar").build();
-		assertEquals("http://example.com?foo=bar", uri.toString());				
+		URI uri = URIBuilder.fromUri("https://example.com?foo=bar").build();
+		assertEquals("https://example.com?foo=bar", uri.toString());				
 	}
 
 	@Test
 	public void buildURIWithExistingAndNewParameters() {
-		URI uri = URIBuilder.fromUri("http://example.com?foo=bar&x=1").queryParam("salt", "NaCl").build();
-		assertEquals("http://example.com?foo=bar&x=1&salt=NaCl", uri.toString());				
+		URI uri = URIBuilder.fromUri("https://example.com?foo=bar&x=1").queryParam("salt", "NaCl").build();
+		assertEquals("https://example.com?foo=bar&x=1&salt=NaCl", uri.toString());				
 	}
 
 	@Test
 	public void buildURIWithOneParameter() {
-		URI uri = URIBuilder.fromUri("http://example.com").queryParam("foo", "bar").build();
-		assertEquals("http://example.com?foo=bar", uri.toString());		
+		URI uri = URIBuilder.fromUri("https://example.com").queryParam("foo", "bar").build();
+		assertEquals("https://example.com?foo=bar", uri.toString());		
 	}
 	
 	@Test
 	public void buildURIWithMultipleParameters() {
-		URI uri = URIBuilder.fromUri("http://example.com").queryParam("foo", "bar").queryParam("abc", "123")
+		URI uri = URIBuilder.fromUri("https://example.com").queryParam("foo", "bar").queryParam("abc", "123")
 			.queryParam("xyz", "987").build();
-		assertEquals("http://example.com?foo=bar&abc=123&xyz=987", uri.toString());		
+		assertEquals("https://example.com?foo=bar&abc=123&xyz=987", uri.toString());		
 	}
 	
 	@Test
 	public void buildURIWithSameNamedParameters() {
-		URI uri = URIBuilder.fromUri("http://example.com").queryParam("foo", "bar").queryParam("foo", "123")
+		URI uri = URIBuilder.fromUri("https://example.com").queryParam("foo", "bar").queryParam("foo", "123")
 			.queryParam("foo", "987").build();
-		assertEquals("http://example.com?foo=bar&foo=123&foo=987", uri.toString());		
+		assertEquals("https://example.com?foo=bar&foo=123&foo=987", uri.toString());		
 	}
 	
 	@Test
 	public void buildURIWithEmptyParameter() {
-		URI uri = URIBuilder.fromUri("http://example.com").queryParam("foo", "").build();
-		assertEquals("http://example.com?foo=", uri.toString());		
+		URI uri = URIBuilder.fromUri("https://example.com").queryParam("foo", "").build();
+		assertEquals("https://example.com?foo=", uri.toString());		
 	}
 	
 	@Test
 	public void buildURIWithNullParameter() {
-		URI uri = URIBuilder.fromUri("http://example.com").queryParam("foo", null).build();
-		assertEquals("http://example.com?foo=", uri.toString());		
+		URI uri = URIBuilder.fromUri("https://example.com").queryParam("foo", null).build();
+		assertEquals("https://example.com?foo=", uri.toString());		
 	}
 	
 	@Test
 	public void buildURIWithFormEncodedParameterValue() {
-		URI uri = URIBuilder.fromUri("http://example.com").queryParam("foo", "2 + 3 = 5").build();
-		assertEquals("http://example.com?foo=2+%2B+3+%3D+5", uri.toString());		
+		URI uri = URIBuilder.fromUri("https://example.com").queryParam("foo", "2 + 3 = 5").build();
+		assertEquals("https://example.com?foo=2+%2B+3+%3D+5", uri.toString());		
 	}
 	
 	@Test
 	public void buildURIWithFormEncodedParameterName() {
-		URI uri = URIBuilder.fromUri("http://example.com").queryParam("f@@", "2 + 3 = 5").build();
-		assertEquals("http://example.com?f%40%40=2+%2B+3+%3D+5", uri.toString());		
+		URI uri = URIBuilder.fromUri("https://example.com").queryParam("f@@", "2 + 3 = 5").build();
+		assertEquals("https://example.com?f%40%40=2+%2B+3+%3D+5", uri.toString());		
 	}
 }

--- a/spring-social-security/src/main/java/org/springframework/social/security/provider/OAuth1AuthenticationService.java
+++ b/spring-social-security/src/main/java/org/springframework/social/security/provider/OAuth1AuthenticationService.java
@@ -81,7 +81,7 @@ public class OAuth1AuthenticationService<S> extends AbstractSocialAuthentication
 
 	public SocialAuthenticationToken getAuthToken(HttpServletRequest request, HttpServletResponse response) throws SocialAuthenticationRedirectException {
 		/**
-		 * OAuth Authentication flow: See http://dev.twitter.com/pages/auth
+		 * OAuth Authentication flow: See https://dev.twitter.com/pages/auth
 		 */
 		String verifier = request.getParameter("oauth_verifier");
 		if (!StringUtils.hasText(verifier)) {

--- a/spring-social-security/src/test/java/org/springframework/social/security/provider/OAuth1AuthenticationServiceTest.java
+++ b/spring-social-security/src/test/java/org/springframework/social/security/provider/OAuth1AuthenticationServiceTest.java
@@ -44,7 +44,7 @@ public class OAuth1AuthenticationServiceTest {
 		final OAuth1ConnectionFactory<Object> factory = mock(OAuth1ConnectionFactory.class);
 		final OAuth1Operations operations = mock(OAuth1Operations.class);
 		final String serverName = "example.com";
-		final String serviceUrl = "http://twitter.com/auth";
+		final String serviceUrl = "https://twitter.com/auth";
 		final OAuthToken oAuthToken = new OAuthToken("my_token", "my_secret");
 		final String verifier = "my_verifier";
 		final Connection<Object> connection = DummyConnection.dummy("provider", "user");

--- a/spring-social-security/src/test/java/org/springframework/social/security/provider/OAuth2AuthenticationServiceTest.java
+++ b/spring-social-security/src/test/java/org/springframework/social/security/provider/OAuth2AuthenticationServiceTest.java
@@ -57,9 +57,9 @@ public class OAuth2AuthenticationServiceTest {
 		when(factory.createConnection(accessGrant)).thenReturn(connection);
 
 		when(
-				operations.buildAuthenticateUrl(oAuth2Parameters("http://example.com/auth/foo?param=param_value"))).thenReturn(
-				"http://facebook.com/auth");
-		when(operations.exchangeForAccess(code, "http://example.com/auth/foo", null)).thenReturn(accessGrant);
+				operations.buildAuthenticateUrl(oAuth2Parameters("https://example.com/auth/foo?param=param_value"))).thenReturn(
+				"https://facebook.com/auth");
+		when(operations.exchangeForAccess(code, "https://example.com/auth/foo", null)).thenReturn(accessGrant);
 
 		// first phase
 		MockHttpServletRequest request = new MockHttpServletRequest(context, "GET", "/auth/foo");
@@ -76,7 +76,7 @@ public class OAuth2AuthenticationServiceTest {
 			//       Ultimately the OAuth2Template creates the redirect URL, but since that's mocked out in this test, that won't be easily
 			//       done without recreating the functionality of a real OAuth2Template. Instead, we can feel confident that if the redirect
 			//       URL is what we told the mock to return, then the mock must have been given the proper return URL.
-			assertEquals("http://facebook.com/auth", e.getRedirectUrl());
+			assertEquals("https://facebook.com/auth", e.getRedirectUrl());
 		}
 
 		// second phase
@@ -116,8 +116,8 @@ public class OAuth2AuthenticationServiceTest {
 
 		when(
 				operations.buildAuthenticateUrl(oAuth2Parameters("http://x.com/auth/foo?param=param_value"))).thenReturn(
-				"http://facebook.com/auth");
-		when(operations.exchangeForAccess(code, "http://example.com/auth/foo", null)).thenReturn(accessGrant);
+				"https://facebook.com/auth");
+		when(operations.exchangeForAccess(code, "https://example.com/auth/foo", null)).thenReturn(accessGrant);
 
 		// first phase
 		MockHttpServletRequest request = new MockHttpServletRequest(context, "GET", "/auth/foo");
@@ -138,7 +138,7 @@ public class OAuth2AuthenticationServiceTest {
 			//       Ultimately the OAuth2Template creates the redirect URL, but since that's mocked out in this test, that won't be easily
 			//       done without recreating the functionality of a real OAuth2Template. Instead, we can feel confident that if the redirect
 			//       URL is what we told the mock to return, then the mock must have been given the proper return URL.
-			assertEquals("http://facebook.com/auth", e.getRedirectUrl());
+			assertEquals("https://facebook.com/auth", e.getRedirectUrl());
 		}
 
 		// second phase

--- a/spring-social-security/src/test/java/org/springframework/social/security/test/DummyConnection.java
+++ b/spring-social-security/src/test/java/org/springframework/social/security/test/DummyConnection.java
@@ -49,11 +49,11 @@ public class DummyConnection<T> implements Connection<T> {
 	}
 
 	public String getProfileUrl() {
-		return "http://www.example.com/" + _key.getProviderUserId();
+		return "https://www.example.com/" + _key.getProviderUserId();
 	}
 
 	public String getImageUrl() {
-		return "http://www.example.com/img/" + _key.getProviderUserId() + ".jpg";
+		return "https://www.example.com/img/" + _key.getProviderUserId() + ".jpg";
 	}
 
 	public void sync() {

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ConnectController.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ConnectController.java
@@ -298,7 +298,7 @@ public class ConnectController implements InitializingBean {
 	}
 	
 	/**
-	 * Process an error callback from an OAuth 2 authorization as described at http://tools.ietf.org/html/rfc6749#section-4.1.2.1.
+	 * Process an error callback from an OAuth 2 authorization as described at https://tools.ietf.org/html/rfc6749#section-4.1.2.1.
 	 * Called after upon redirect from an OAuth 2 provider when there is some sort of error during authorization, typically because the user denied authorization.
 	 * @param providerId the provider ID that the connection was attempted for
 	 * @param error the error parameter sent from the provider

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInController.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/ProviderSignInController.java
@@ -234,7 +234,7 @@ public class ProviderSignInController implements InitializingBean {
 	}
 
 	/**
-	 * Process an error callback from an OAuth 2 authorization as described at http://tools.ietf.org/html/rfc6749#section-4.1.2.1.
+	 * Process an error callback from an OAuth 2 authorization as described at https://tools.ietf.org/html/rfc6749#section-4.1.2.1.
 	 * Called after upon redirect from an OAuth 2 provider when there is some sort of error during authorization, typically because the user denied authorization.
 	 * Simply carries the error parameters through to the sign-in page.
 	 * @param providerId The Provider ID

--- a/spring-social-web/src/main/java/org/springframework/social/connect/web/taglib/SocialConnectedTag.java
+++ b/spring-social-web/src/main/java/org/springframework/social/connect/web/taglib/SocialConnectedTag.java
@@ -21,7 +21,7 @@ package org.springframework.social.connect.web.taglib;
  * Sample usages in JSP:
  *
  * Include at top of JSP:
- * &lt;%@ taglib prefix="social" uri="http://org.springframework/social" %&gt;
+ * &lt;%@ taglib prefix="social" uri="https://org.springframework/social" %&gt;
  *
  * &lt;social:connected provider="facebook"&gt;
  * 	    [ show some FB profile info ]

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/ConnectControllerTest.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/ConnectControllerTest.java
@@ -71,7 +71,7 @@ public class ConnectControllerTest {
 		ConnectionFactoryRegistry connectionFactoryLocator = new ConnectionFactoryRegistry();
 		ConnectionRepository connectionRepository = new InMemoryUsersConnectionRepository(connectionFactoryLocator).createConnectionRepository("userid");
 		ConnectController controller = new ConnectController(connectionFactoryLocator, connectionRepository);
-		controller.setApplicationUrl("http://baseurl.com/");
+		controller.setApplicationUrl("http://baseurl.com/?folio=9PO6Z3MVF&_glst=0&rfolio=9POV2OOG7");
 	}
 	
 	@Test
@@ -333,10 +333,10 @@ public class ConnectControllerTest {
 		HashMap<String, String> expectedError = new HashMap<String, String>();
 		expectedError.put("error", "access_denied");
 		expectedError.put("errorDescription", "The user said no.");
-		expectedError.put("errorUri", "http://provider.com/user/said/no");
+		expectedError.put("errorUri", "https://provider.com/user/said/no");
 		mockMvc.perform(get("/connect/oauth2Provider").param("error", "access_denied")
 													  .param("error_description", "The user said no.")
-													  .param("error_uri", "http://provider.com/user/said/no"))
+													  .param("error_uri", "https://provider.com/user/said/no"))
 			.andExpect(redirectedUrl("/connect/oauth2Provider"))
 			.andExpect(request().sessionAttribute("social_authorization_error", notNullValue()))
 			.andExpect(request().sessionAttribute("social_authorization_error", expectedError));

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/ConnectSupportTest.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/ConnectSupportTest.java
@@ -101,14 +101,14 @@ public class ConnectSupportTest {
 	@Test
 	public void buildOAuthUrl_OAuth10_withApplicationUrlHavingDeepPath() throws Exception {
 		ConnectSupport support = new ConnectSupport();
-		support.setApplicationUrl("http://ec2.instance.com:8080/spring-social/showcase");
+		support.setApplicationUrl("https://ec2.instance.com:8080/spring-social/showcase");
 		MockHttpServletRequest mockRequest = new PortAwareMockHttpServletRequest();
 		mockRequest.setScheme("http");
 		mockRequest.setServerName("somesite.com");
 		mockRequest.setServletPath("/connect/someprovider");
 		ServletWebRequest request = new ServletWebRequest(mockRequest);
 		String url = support.buildOAuthUrl(new TestOAuth1ConnectionFactory(OAuth1Version.CORE_10), request);
-		assertEquals("https://serviceprovider.com/oauth/authorize?oauth_callback=http://ec2.instance.com:8080/spring-social/showcase/connect/someprovider", url);
+		assertEquals("https://serviceprovider.com/oauth/authorize?oauth_callback=https://ec2.instance.com:8080/spring-social/showcase/connect/someprovider", url);
 	}
 	
 	@Test
@@ -261,14 +261,14 @@ public class ConnectSupportTest {
 	@Test
 	public void buildOAuthUrl_OAuth2_withApplicationUrlHavingDeepPath() throws Exception {
 		ConnectSupport support = new ConnectSupport();
-		support.setApplicationUrl("http://ec2.instance.com:8080/spring-social/showcase");
+		support.setApplicationUrl("https://ec2.instance.com:8080/spring-social/showcase");
 		MockHttpServletRequest mockRequest = new PortAwareMockHttpServletRequest();
 		mockRequest.setScheme("http");
 		mockRequest.setServerName("somesite.com");
 		mockRequest.setServletPath("/connect/someprovider");
 		ServletWebRequest request = new ServletWebRequest(mockRequest);
 		String url = support.buildOAuthUrl(new TestOAuth2ConnectionFactory(), request);
-		assertEquals("https://serviceprovider.com/oauth/authorize?redirect_uri=http://ec2.instance.com:8080/spring-social/showcase/connect/someprovider&state=STATE", url);
+		assertEquals("https://serviceprovider.com/oauth/authorize?redirect_uri=https://ec2.instance.com:8080/spring-social/showcase/connect/someprovider&state=STATE", url);
 	}
 
 	@Test
@@ -345,7 +345,7 @@ public class ConnectSupportTest {
 		ServletWebRequest request = new ServletWebRequest(mockRequest);
 		Connection<?> connection = support.completeConnection(new TestOAuth1ConnectionFactory(OAuth1Version.CORE_10_REVISION_A), request);
 		assertEquals("TestUser", connection.getDisplayName());
-		assertEquals("http://someprovider.com/images/testuser.jpg", connection.getImageUrl());
+		assertEquals("http://someprovider.com/?f", connection.getImageUrl());
 		assertEquals("http://someprovider.com/testuser", connection.getProfileUrl());
 	}
 
@@ -362,7 +362,7 @@ public class ConnectSupportTest {
 		ServletWebRequest request = new ServletWebRequest(mockRequest);
 		Connection<?> connection = support.completeConnection(new TestOAuth2ConnectionFactory(), request);
 		assertEquals("TestUser", connection.getDisplayName());
-		assertEquals("http://someprovider.com/images/testuser.jpg", connection.getImageUrl());
+		assertEquals("http://someprovider.com/?f", connection.getImageUrl());
 		assertEquals("http://someprovider.com/testuser", connection.getProfileUrl());
 	}
 
@@ -543,7 +543,7 @@ public class ConnectSupportTest {
 
 		public void setConnectionValues(TestApi api, ConnectionValues values) {
 			values.setDisplayName("TestUser");
-			values.setImageUrl("http://someprovider.com/images/testuser.jpg");
+			values.setImageUrl("http://someprovider.com/?f");
 			values.setProfileUrl("http://someprovider.com/testuser");
 			values.setProviderUserId("testuser");
 		}

--- a/spring-social-web/src/test/java/org/springframework/social/connect/web/ProviderSignInControllerTest.java
+++ b/spring-social-web/src/test/java/org/springframework/social/connect/web/ProviderSignInControllerTest.java
@@ -280,7 +280,7 @@ public class ProviderSignInControllerTest {
 		mockMvc.perform(get("/signin/oauth2Provider")
 			.param("error", "access_denied")
 			.param("error_description", "The user said no.")
-			.param("error_uri", "http://provider.com/user/said/no"))
+			.param("error_uri", "https://provider.com/user/said/no"))
 			.andExpect(redirectedUrl("/signin?error=access_denied&error_description=The+user+said+no.&error_uri=http%3A%2F%2Fprovider.com%2Fuser%2Fsaid%2Fno"));
 	}
 

--- a/src/api/overview.html
+++ b/src/api/overview.html
@@ -5,7 +5,7 @@ This document is the API specification for Spring Social
 <div id="overviewBody">
     <p>
         If you are interested in commercial training, consultancy, and
-        support for Spring Social, please visit <a href="http://www.springsource.com/" target="_top">SpringSource.com</a>.
+        support for Spring Social, please visit <a href="https://www.springsource.com/" target="_top">SpringSource.com</a>.
     </p>
 </div>
 </body>

--- a/src/dist/notice.txt
+++ b/src/dist/notice.txt
@@ -4,13 +4,13 @@
    ========================================================================
 
    This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+   the Apache Software Foundation (https://www.apache.org).
 
    The end-user documentation included with a redistribution, if any,
    must include the following acknowledgement:
 
      "This product includes software developed by the Spring Framework
-      Project (http://www.springframework.org)."
+      Project (https://www.springframework.org)."
 
    Alternatively, this acknowledgement may appear in the software itself,
    if and wherever such third-party acknowledgements normally appear.

--- a/src/dist/readme.txt
+++ b/src/dist/readme.txt
@@ -6,7 +6,7 @@ It consists of a service provider 'connect' framework, sign-in support, and stro
 To find out what has changed in this release, see 'changelog.txt'
 
 Please consult the documentation located within the 'docs/reference' directory of this release and also visit the official Spring Social home at:
-http://www.springsource.org/spring-social
+https://www.springsource.org/spring-social
 
 There you will find links to the forum, issue tracker, samples, and other resources.
  


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/fo/highlight.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/fo/highlight.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl (200) with 1 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/html/docbook.xsl) result AnnotatedConnectException).
* [ ] http://docbook.sourceforge.net/release/xsl/current/html/highlight.xsl (200) with 2 occurrences could not be migrated:  
   ([https](https://docbook.sourceforge.net/release/xsl/current/html/highlight.xsl) result AnnotatedConnectException).
* [ ] http://someprovider.com/testuser (200) with 3 occurrences could not be migrated:  
   ([https](https://someprovider.com/testuser) result AnnotatedConnectException).
* [ ] http://somesite.com/appname/connect/someprovider (200) with 1 occurrences could not be migrated:  
   ([https](https://somesite.com/appname/connect/someprovider) result AnnotatedConnectException).
* [ ] http://somesite.com/connect/someprovider (200) with 4 occurrences could not be migrated:  
   ([https](https://somesite.com/connect/someprovider) result AnnotatedConnectException).
* [ ] http://somesite.com/connect/someprovider&state=STATE (200) with 4 occurrences could not be migrated:  
   ([https](https://somesite.com/connect/someprovider&state=STATE) result AnnotatedConnectException).
* [ ] http://someurl.com/foo/bar (200) with 2 occurrences could not be migrated:  
   ([https](https://someurl.com/foo/bar) result SSLHandshakeException).
* [ ] http://someurl.com/foo/bar?abc=123 (200) with 2 occurrences could not be migrated:  
   ([https](https://someurl.com/foo/bar?abc=123) result SSLHandshakeException).
* [ ] http://www.someprovider.com/oauth/accessToken (200) with 2 occurrences could not be migrated:  
   ([https](https://www.someprovider.com/oauth/accessToken) result AnnotatedConnectException).
* [ ] http://www.someprovider.com/oauth/authorize (200) with 1 occurrences could not be migrated:  
   ([https](https://www.someprovider.com/oauth/authorize) result AnnotatedConnectException).
* [ ] http://xslthl.sf.net (301) with 3 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://baseurl.com/ (302) with 1 occurrences could not be migrated:  
   ([https](https://baseurl.com/) result AnnotatedConnectException).
* [ ] http://somehost.com/test (302) with 2 occurrences could not be migrated:  
   ([https](https://somehost.com/test) result ConnectTimeoutException).
* [ ] http://someprovider.com/images/testuser.jpg (302) with 3 occurrences could not be migrated:  
   ([https](https://someprovider.com/images/testuser.jpg) result AnnotatedConnectException).
* [ ] http://loopfuse.net/webrecorder/js/listen.js (404) with 2 occurrences could not be migrated:  
   ([https](https://loopfuse.net/webrecorder/js/listen.js) result SSLHandshakeException).
* [ ] http://x.com/auth/foo?param=param_value (404) with 1 occurrences could not be migrated:  
   ([https](https://x.com/auth/foo?param=param_value) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.mycoolapp.com/connect/facebook (302) with 2 occurrences migrated to:  
  https://www.hugedomains.com/domain_profile.cfm?d=mycoolapp&e=com ([https](https://www.mycoolapp.com/connect/facebook) result ConnectTimeoutException).
* [ ] http://a0.twimg.com/profile_images/105951287/IMG_5863_2_normal.jpg (UnknownHostException) with 1 occurrences migrated to:  
  https://a0.twimg.com/profile_images/105951287/IMG_5863_2_normal.jpg ([https](https://a0.twimg.com/profile_images/105951287/IMG_5863_2_normal.jpg) result UnknownHostException).
* [ ] http://ec2.instance.com:8080/spring-social/showcase (UnknownHostException) with 2 occurrences migrated to:  
  https://ec2.instance.com:8080/spring-social/showcase ([https](https://ec2.instance.com:8080/spring-social/showcase) result UnknownHostException).
* [ ] http://ec2.instance.com:8080/spring-social/showcase/connect/someprovider (UnknownHostException) with 1 occurrences migrated to:  
  https://ec2.instance.com:8080/spring-social/showcase/connect/someprovider ([https](https://ec2.instance.com:8080/spring-social/showcase/connect/someprovider) result UnknownHostException).
* [ ] http://ec2.instance.com:8080/spring-social/showcase/connect/someprovider&state=STATE (UnknownHostException) with 1 occurrences migrated to:  
  https://ec2.instance.com:8080/spring-social/showcase/connect/someprovider&state=STATE ([https](https://ec2.instance.com:8080/spring-social/showcase/connect/someprovider&state=STATE) result UnknownHostException).
* [ ] http://fake.com/auth (UnknownHostException) with 1 occurrences migrated to:  
  https://fake.com/auth ([https](https://fake.com/auth) result UnknownHostException).
* [ ] http://fake.com/token (UnknownHostException) with 1 occurrences migrated to:  
  https://fake.com/token ([https](https://fake.com/token) result UnknownHostException).
* [ ] http://jackson.codehaus.org/ (UnknownHostException) with 1 occurrences migrated to:  
  https://jackson.codehaus.org/ ([https](https://jackson.codehaus.org/) result UnknownHostException).
* [ ] http://org.springframework/social (UnknownHostException) with 1 occurrences migrated to:  
  https://org.springframework/social ([https](https://org.springframework/social) result UnknownHostException).
* [ ] http://www.someclient.com/callback (UnknownHostException) with 1 occurrences migrated to:  
  https://www.someclient.com/callback ([https](https://www.someclient.com/callback) result UnknownHostException).
* [ ] http://www.someclient.com/connect/foo (UnknownHostException) with 4 occurrences migrated to:  
  https://www.someclient.com/connect/foo ([https](https://www.someclient.com/connect/foo) result UnknownHostException).
* [ ] http://www.someclient.com/oauth/callback (UnknownHostException) with 4 occurrences migrated to:  
  https://www.someclient.com/oauth/callback ([https](https://www.someclient.com/oauth/callback) result UnknownHostException).
* [ ] http://docs.spring.io/spring-social-facebook/site/docs/1.1.0.RC1/reference/htmlsingle/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social-facebook/site/docs/1.1.0.RC1/reference/htmlsingle/ ([https](https://docs.spring.io/spring-social-facebook/site/docs/1.1.0.RC1/reference/htmlsingle/) result 404).
* [ ] http://docs.spring.io/spring-social-linkedin/site/docs/1.1.0.RC1/reference/htmlsingle/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social-linkedin/site/docs/1.1.0.RC1/reference/htmlsingle/ ([https](https://docs.spring.io/spring-social-linkedin/site/docs/1.1.0.RC1/reference/htmlsingle/) result 404).
* [ ] http://docs.spring.io/spring-social-twitter/site/docs/1.1.0.RC1/reference/htmlsingle/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social-twitter/site/docs/1.1.0.RC1/reference/htmlsingle/ ([https](https://docs.spring.io/spring-social-twitter/site/docs/1.1.0.RC1/reference/htmlsingle/) result 404).
* [ ] http://example.com/auth/foo (404) with 2 occurrences migrated to:  
  https://example.com/auth/foo ([https](https://example.com/auth/foo) result 404).
* [ ] http://example.com/auth/foo?param=param_value (404) with 1 occurrences migrated to:  
  https://example.com/auth/foo?param=param_value ([https](https://example.com/auth/foo?param=param_value) result 404).
* [ ] http://example.com/request (404) with 4 occurrences migrated to:  
  https://example.com/request ([https](https://example.com/request) result 404).
* [ ] http://help.github.com/send-pull-requests (404) with 1 occurrences migrated to:  
  https://help.github.com/send-pull-requests ([https](https://help.github.com/send-pull-requests) result 404).
* [ ] http://provider.com/user/said/no (302) with 3 occurrences migrated to:  
  https://provider.com/user/said/no ([https](https://provider.com/user/said/no) result 404).
* [ ] http://twitter.com/auth (301) with 1 occurrences migrated to:  
  https://twitter.com/auth ([https](https://twitter.com/auth) result 404).
* [ ] http://twitter.com/kdonald/a_new_picture (301) with 4 occurrences migrated to:  
  https://twitter.com/kdonald/a_new_picture ([https](https://twitter.com/kdonald/a_new_picture) result 404).
* [ ] http://www.example.com/img/ (404) with 2 occurrences migrated to:  
  https://www.example.com/img/ ([https](https://www.example.com/img/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-social-facebook/docs/current/apidocs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social-facebook/docs/current/apidocs/ ([https](https://docs.spring.io/spring-social-facebook/docs/current/apidocs/) result 200).
* [ ] http://docs.spring.io/spring-social-facebook/docs/current/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social-facebook/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-social-facebook/docs/current/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-social-linkedin/docs/1.0.x/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social-linkedin/docs/1.0.x/api/ ([https](https://docs.spring.io/spring-social-linkedin/docs/1.0.x/api/) result 200).
* [ ] http://docs.spring.io/spring-social-linkedin/docs/1.0.x/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social-linkedin/docs/1.0.x/reference/htmlsingle/ ([https](https://docs.spring.io/spring-social-linkedin/docs/1.0.x/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-social-twitter/docs/current/apidocs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social-twitter/docs/current/apidocs/ ([https](https://docs.spring.io/spring-social-twitter/docs/current/apidocs/) result 200).
* [ ] http://docs.spring.io/spring-social-twitter/docs/current/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social-twitter/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-social-twitter/docs/current/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-social/docs/current-SNAPSHOT/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social/docs/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/spring-social/docs/current-SNAPSHOT/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-social/docs/current/apidocs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-social/docs/current/apidocs/ ([https](https://docs.spring.io/spring-social/docs/current/apidocs/) result 200).
* [ ] http://docs.spring.io/spring/docs/3.0.x/javadoc-api/org/springframework/web/filter/HiddenHttpMethodFilter.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/javadoc-api/org/springframework/web/filter/HiddenHttpMethodFilter.html ([https](https://docs.spring.io/spring/docs/3.0.x/javadoc-api/org/springframework/web/filter/HiddenHttpMethodFilter.html) result 200).
* [ ] http://example.com with 9 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://example.com?f%40%40=2+%2B+3+%3D+5 with 1 occurrences migrated to:  
  https://example.com?f%40%40=2+%2B+3+%3D+5 ([https](https://example.com?f%40%40=2+%2B+3+%3D+5) result 200).
* [ ] http://example.com?foo= with 2 occurrences migrated to:  
  https://example.com?foo= ([https](https://example.com?foo=) result 200).
* [ ] http://example.com?foo=2+%2B+3+%3D+5 with 1 occurrences migrated to:  
  https://example.com?foo=2+%2B+3+%3D+5 ([https](https://example.com?foo=2+%2B+3+%3D+5) result 200).
* [ ] http://example.com?foo=bar with 3 occurrences migrated to:  
  https://example.com?foo=bar ([https](https://example.com?foo=bar) result 200).
* [ ] http://example.com?foo=bar&abc=123&xyz=987 with 1 occurrences migrated to:  
  https://example.com?foo=bar&abc=123&xyz=987 ([https](https://example.com?foo=bar&abc=123&xyz=987) result 200).
* [ ] http://example.com?foo=bar&foo=123&foo=987 with 1 occurrences migrated to:  
  https://example.com?foo=bar&foo=123&foo=987 ([https](https://example.com?foo=bar&foo=123&foo=987) result 200).
* [ ] http://example.com?foo=bar&x=1 with 1 occurrences migrated to:  
  https://example.com?foo=bar&x=1 ([https](https://example.com?foo=bar&x=1) result 200).
* [ ] http://example.com?foo=bar&x=1&salt=NaCl with 1 occurrences migrated to:  
  https://example.com?foo=bar&x=1&salt=NaCl ([https](https://example.com?foo=bar&x=1&salt=NaCl) result 200).
* [ ] http://gradle.org with 1 occurrences migrated to:  
  https://gradle.org ([https](https://gradle.org) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://tools.ietf.org/html/rfc5849 with 4 occurrences migrated to:  
  https://tools.ietf.org/html/rfc5849 ([https](https://tools.ietf.org/html/rfc5849) result 200).
* [ ] http://tools.ietf.org/html/rfc6749 with 2 occurrences migrated to:  
  https://tools.ietf.org/html/rfc6749 ([https](https://tools.ietf.org/html/rfc6749) result 200).
* [ ] http://twitter.com/jbauer with 1 occurrences migrated to:  
  https://twitter.com/jbauer ([https](https://twitter.com/jbauer) result 200).
* [ ] http://twitter.com/kdonald with 3 occurrences migrated to:  
  https://twitter.com/kdonald ([https](https://twitter.com/kdonald) result 200).
* [ ] http://www.apache.org with 2 occurrences migrated to:  
  https://www.apache.org ([https](https://www.apache.org) result 200).
* [ ] http://www.example.com/ with 2 occurrences migrated to:  
  https://www.example.com/ ([https](https://www.example.com/) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://developers.facebook.com/docs/authentication/permissions with 1 occurrences migrated to:  
  https://developers.facebook.com/docs/authentication/permissions ([https](https://developers.facebook.com/docs/authentication/permissions) result 301).
* [ ] http://facebook.com/auth with 4 occurrences migrated to:  
  https://facebook.com/auth ([https](https://facebook.com/auth) result 301).
* [ ] http://facebook.com/keith.donald with 3 occurrences migrated to:  
  https://facebook.com/keith.donald ([https](https://facebook.com/keith.donald) result 301).
* [ ] http://facebook.com/keith.donald/picture with 3 occurrences migrated to:  
  https://facebook.com/keith.donald/picture ([https](https://facebook.com/keith.donald/picture) result 301).
* [ ] http://hc.apache.org/httpcomponents-client-ga with 1 occurrences migrated to:  
  https://hc.apache.org/httpcomponents-client-ga ([https](https://hc.apache.org/httpcomponents-client-ga) result 301).
* [ ] http://jira.springsource.org/browse/SOCIAL with 1 occurrences migrated to:  
  https://jira.springsource.org/browse/SOCIAL ([https](https://jira.springsource.org/browse/SOCIAL) result 301).
* [ ] http://projects.spring.io/spring-framework with 1 occurrences migrated to:  
  https://projects.spring.io/spring-framework ([https](https://projects.spring.io/spring-framework) result 301).
* [ ] http://projects.spring.io/spring-social with 1 occurrences migrated to:  
  https://projects.spring.io/spring-social ([https](https://projects.spring.io/spring-social) result 301).
* [ ] http://twitter.com/kdonald/picture with 3 occurrences migrated to:  
  https://twitter.com/kdonald/picture ([https](https://twitter.com/kdonald/picture) result 301).
* [ ] http://www.springframework.org with 2 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* [ ] http://www.springsource.com/ with 1 occurrences migrated to:  
  https://www.springsource.com/ ([https](https://www.springsource.com/) result 301).
* [ ] http://www.springsource.org/documentation with 1 occurrences migrated to:  
  https://www.springsource.org/documentation ([https](https://www.springsource.org/documentation) result 301).
* [ ] http://www.springsource.org/spring-social with 1 occurrences migrated to:  
  https://www.springsource.org/spring-social ([https](https://www.springsource.org/spring-social) result 301).
* [ ] http://www.twitter.com/mcbob with 2 occurrences migrated to:  
  https://www.twitter.com/mcbob ([https](https://www.twitter.com/mcbob) result 301).
* [ ] http://dev.twitter.com/pages/auth with 2 occurrences migrated to:  
  https://dev.twitter.com/pages/auth ([https](https://dev.twitter.com/pages/auth) result 302).
* [ ] http://maven.springframework.org/milestone with 1 occurrences migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* [ ] http://maven.springframework.org/snapshot with 1 occurrences migrated to:  
  https://maven.springframework.org/snapshot ([https](https://maven.springframework.org/snapshot) result 302).
* [ ] http://repo.spring.io/milestone with 2 occurrences migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* [ ] http://repo.spring.io/release with 1 occurrences migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).
* [ ] http://repo.spring.io/snapshot with 2 occurrences migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).
* [ ] http://springsource.org/oauth/authenticate?request_token= with 1 occurrences migrated to:  
  https://springsource.org/oauth/authenticate?request_token= ([https](https://springsource.org/oauth/authenticate?request_token=) result 302).
* [ ] http://springsource.org/oauth/authorize?request_token= with 1 occurrences migrated to:  
  https://springsource.org/oauth/authorize?request_token= ([https](https://springsource.org/oauth/authorize?request_token=) result 302).
* [ ] http://springsource.org/oauth/authorize?scope= with 2 occurrences migrated to:  
  https://springsource.org/oauth/authorize?scope= ([https](https://springsource.org/oauth/authorize?scope=) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 3 occurrences
* http://fake/access with 1 occurrences
* http://fake/auth with 2 occurrences
* http://fake/request with 1 occurrences
* http://fake/token with 1 occurrences
* http://java.sun.com/xml/ns/javaee with 2 occurrences
* http://localhost/register with 2 occurrences
* http://localhost:3005/the_dance/process_callback?service_provider_id=11 with 1 occurrences
* http://somehost/somepath/signup with 1 occurrences
* http://somehost:8080/spring-social-showcase with 1 occurrences
* http://somehost:8080/spring-social-showcase/foo/connect/someprovider with 1 occurrences
* http://www with 2 occurrences
* http://www.springframework.org/schema/social with 2 occurrences
* http://www.springframework.org/schema/social/fake with 2 occurrences
* http://www.springframework.org/spring-social/social/tags with 1 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 3 occurrences
* http://www.w3.org/2001/XMLSchema with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences